### PR TITLE
Add builtins (pwd)

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -72,6 +72,7 @@ impl ShellCore {
         core.builtins.insert("cd".to_string(), builtins::cd);
         core.builtins.insert("exit".to_string(), builtins::exit);
         core.builtins.insert("false".to_string(), builtins::false_);
+        core.builtins.insert("pwd".to_string(), builtins::pwd);
         core.builtins.insert("true".to_string(), builtins::true_);
 
         core

--- a/src/core/builtins.rs
+++ b/src/core/builtins.rs
@@ -50,6 +50,19 @@ pub fn cd(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     }
 }
 
+pub fn pwd(_: &mut ShellCore, _: &mut Vec<String>) -> i32 {
+    match env::current_dir() {
+        Ok(path) => {
+            println!("{}", path.display());
+            0
+        },
+        Err(err) => {
+            eprintln!("pwd: error retrieving current directory: {:?}", err);
+            1
+        }
+    }
+}
+
 pub fn true_(_: &mut ShellCore, _: &mut Vec<String>) -> i32 {
     0
 }


### PR DESCRIPTION
bashではpwd実行時、getcwd()せずなんらかの内部変数を参照するように見える。おそらく内部変数は起動時とカレント移動時に設定される。しかし$PWDとは値が同期していないので、内部変数は別に管理されている。
※要追加調査（この実装ではカレント削除後のpwdが出ない）

bashのふるまいメモ
```bash
bash5.2$ mkdir t
bash5.2$ cd t
bash5.2$ rmdir ../t
bash5.2$ pwd
/rusty_bash/t
bash5.2$ echo $SHLVL
2
bash5.2$ bash
shell-init: カレントディレクトリの取得時にエラーが発生しました : getcwd: 親ディレクトリにアクセスできません: そのようなファイルやディレクトリはありません
sh: 0: getcwd() failed: No such file or directory
bash5.2$ echo $?
0
bash5.2$ echo $SHLVL
3
bash5.2$ pwd
pwd: カレントディレクトリの取得時にエラーが発生しました : getcwd: 親ディレクトリにアクセスできません: そのようなファイルやディレクトリはありません
bash5.2$ echo $?
1
bash5.2$ /bin/pwd
/bin/pwd: `..' の中に i ノードが一致しているディレクトリが見つかりません
bash5.2$ echo $?
1
bash5.2$ echo $PWD
/rusty_bash/t
```
