### PR TITLE
Add MACHTYPE, BASH_VERSINFO, and change BASH_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Bash Variables
 | BASH_COMMAND | :no_good: | BASH_COMPAT | :no_good: | BASH_ENV | :no_good: |
 | BASH_EXECUTION_STRING | :no_good: | BASH_LINENO | :no_good: | BASH_LOADABLES_PATH | :no_good: |
 | BASH_REMATCH | :no_good: | BASH_SOURCE | :no_good: | BASH_SUBSHELL | :heavy_check_mark: |
-| BASH_VERSINFO | :no_good: | BASH_VERSION | :heavy_check_mark: | BASH_XTRACEFD | :no_good: |
+| BASH_VERSINFO | :heavy_check_mark: | BASH_VERSION | :heavy_check_mark: | BASH_XTRACEFD | :no_good: |
 | CHILD_MAX | :no_good: | COLUMNS | :no_good: | COMP_CWORD | :no_good: |
 | COMP_LINE | :no_good: | COMP_POINT | :no_good: | COMP_TYPE | :no_good: |
 | COMP_KEY | :no_good: | COMP_WORDBREAKS | :no_good: | COMP_WORDS | :no_good: |
@@ -190,7 +190,7 @@ Bash Variables
 | INPUTRC | :no_good: | INSIDE_EMACS | :no_good: | LANG | :heavy_check_mark: |
 | LC_ALL | :no_good: | LC_COLLATE | :no_good: | LC_CTYPE | :no_good: |
 | LC_MESSAGES | :no_good: | LC_NUMERIC | :no_good: | LC_TIME | :no_good: |
-| LINENO | :heavy_check_mark: | LINES | :no_good: | MACHTYPE | :no_good: |
+| LINENO | :heavy_check_mark: | LINES | :no_good: | MACHTYPE | :heavy_check_mark: |
 | MAILCHECK | :no_good: | MAPFILE | :no_good: | OLDPWD | :heavy_check_mark: |
 | OPTERR | :no_good: | OSTYPE | :no_good: | PIPESTATUS | :heavy_check_mark: |
 | POSIXLY_CORRECT | :no_good: | PPID | :no_good: | PROMPT_COMMAND | :no_good: |

--- a/README.md
+++ b/README.md
@@ -186,13 +186,13 @@ Bash Variables
 | histchars | :no_good: | HISTCMD | :no_good: | HISTCONTROL | :no_good: |
 | HISTFILE | :heavy_check_mark: | HISTFILESIZE | :heavy_check_mark: | HISTIGNORE | :no_good: |
 | HISTSIZE | :no_good: | HISTTIMEFORMAT | :no_good: | HOSTFILE | :no_good: |
-| HOSTNAME | :no_good: | HOSTTYPE | :no_good: | IGNOREEOF | :no_good: |
+| HOSTNAME | :no_good: | HOSTTYPE | :heavy_check_mark: | IGNOREEOF | :no_good: |
 | INPUTRC | :no_good: | INSIDE_EMACS | :no_good: | LANG | :heavy_check_mark: |
 | LC_ALL | :no_good: | LC_COLLATE | :no_good: | LC_CTYPE | :no_good: |
 | LC_MESSAGES | :no_good: | LC_NUMERIC | :no_good: | LC_TIME | :no_good: |
 | LINENO | :heavy_check_mark: | LINES | :no_good: | MACHTYPE | :heavy_check_mark: |
 | MAILCHECK | :no_good: | MAPFILE | :no_good: | OLDPWD | :heavy_check_mark: |
-| OPTERR | :no_good: | OSTYPE | :no_good: | PIPESTATUS | :heavy_check_mark: |
+| OPTERR | :no_good: | OSTYPE | :heavy_check_mark: | PIPESTATUS | :heavy_check_mark: |
 | POSIXLY_CORRECT | :no_good: | PPID | :no_good: | PROMPT_COMMAND | :no_good: |
 | PROMPT_DIRTRIM | :no_good: | PS0 | :no_good: | PS3 | :no_good: |
 | PS4 | :heavy_check_mark: | PWD | :heavy_check_mark: | RANDOM | :no_good: |

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,13 @@
 use std::env;
 
 fn main() {
-    if let Ok(profile) = env::var("PROFILE") {
-        println!("cargo:rustc-env=CARGO_BUILD_PROFILE={}", profile);
-    }
+    // BASH_VERSION, BASH_VERSINFO[4]
+    let profile = env::var("PROFILE").unwrap_or("".to_string());
+    println!("cargo:rustc-env=CARGO_BUILD_PROFILE={}", profile);
+    // MACHTYPE, BASH_VERSINFO[5]
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or("unknown".to_string());
+    let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap_or("unknown".to_string());
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or("unknown".to_string());    
+    let target_gnu_format = format!("{}-{}-{}", target_arch, target_vendor, target_os);
+    println!("cargo:rustc-env=CARGO_CFG_TARGET_GNU_FORMAT={}", target_gnu_format);
 }

--- a/build.rs
+++ b/build.rs
@@ -4,10 +4,13 @@ fn main() {
     // BASH_VERSION, BASH_VERSINFO[4]
     let profile = env::var("PROFILE").unwrap_or("".to_string());
     println!("cargo:rustc-env=CARGO_BUILD_PROFILE={}", profile);
-    // MACHTYPE, BASH_VERSINFO[5]
+    // HOSTTYPE, MACHTYPE, BASH_VERSINFO[5]
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or("unknown".to_string());
+    println!("cargo:rustc-env=CARGO_CFG_TARGET_ARCH={}", target_arch);
+    // MACHTYPE, BASH_VERSINFO[5]
     let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap_or("unknown".to_string());
+    println!("cargo:rustc-env=CARGO_CFG_TARGET_VENDOR={}", target_vendor);
+    // OSTYPE, MACHTYPE, BASH_VERSINFO[5]
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or("unknown".to_string());    
-    let target_gnu_format = format!("{}-{}-{}", target_arch, target_vendor, target_os);
-    println!("cargo:rustc-env=CARGO_CFG_TARGET_GNU_FORMAT={}", target_gnu_format);
+    println!("cargo:rustc-env=CARGO_CFG_TARGET_OS={}", target_os);
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -129,10 +129,20 @@ impl ShellCore {
     }
 
     fn set_initial_parameters(&mut self) {
+        let version = env!("CARGO_PKG_VERSION").to_string();
+        let profile = env!("CARGO_BUILD_PROFILE").to_string();
+        let machtype = env!("CARGO_CFG_TARGET_GNU_FORMAT").to_string();
+        let symbol = "rusty_bash".to_string();
+        let vparts: Vec<&str> = version.split('.').collect();
+        let versinfo = vec![vparts[0].to_string(), vparts[1].to_string(), vparts[2].to_string(),
+                             symbol.clone(), profile.clone(), machtype.clone()];
+
         self.data.set_param("$", &process::id().to_string());
         self.data.set_param("BASHPID", &process::id().to_string());
         self.data.set_param("BASH_SUBSHELL", "0");
-        self.data.set_param("BASH_VERSION", &format!("{}-rusty_bash-{}", env!("CARGO_PKG_VERSION"), env!("CARGO_BUILD_PROFILE")));
+        self.data.set_param("BASH_VERSION", &format!("{}({})-{}", version, symbol, profile));
+        self.data.set_param("MACHTYPE", &machtype);
+        self.data.set_array("BASH_VERSINFO", &versinfo);
         self.data.set_param("?", "0");
         self.data.set_param("HOME", &env::var("HOME").unwrap_or("/".to_string()));
     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -131,7 +131,10 @@ impl ShellCore {
     fn set_initial_parameters(&mut self) {
         let version = env!("CARGO_PKG_VERSION").to_string();
         let profile = env!("CARGO_BUILD_PROFILE").to_string();
-        let machtype = env!("CARGO_CFG_TARGET_GNU_FORMAT").to_string();
+        let t_arch = env!("CARGO_CFG_TARGET_ARCH").to_string();
+        let t_vendor = env!("CARGO_CFG_TARGET_VENDOR").to_string();
+        let t_os = env!("CARGO_CFG_TARGET_OS").to_string();
+        let machtype = format!("{}-{}-{}", t_arch, t_vendor, t_os);
         let symbol = "rusty_bash".to_string();
         let vparts: Vec<&str> = version.split('.').collect();
         let versinfo = vec![vparts[0].to_string(), vparts[1].to_string(), vparts[2].to_string(),
@@ -142,6 +145,8 @@ impl ShellCore {
         self.data.set_param("BASH_SUBSHELL", "0");
         self.data.set_param("BASH_VERSION", &format!("{}({})-{}", version, symbol, profile));
         self.data.set_param("MACHTYPE", &machtype);
+        self.data.set_param("HOSTTYPE", &t_arch);
+        self.data.set_param("OSTYPE", &t_os);
         self.data.set_array("BASH_VERSINFO", &versinfo);
         self.data.set_param("?", "0");
         self.data.set_param("HOME", &env::var("HOME").unwrap_or("/".to_string()));


### PR DESCRIPTION
BASH_VERSINFO[3] : The build version を固定文字列 "rusty_bash" として、文字列解析上の非互換が最小限になるよう辻褄を合わせました。