### PR TITLE
Add --help support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Followings are not difficult but very important tasks.
 | -c | :heavy_check_mark: | -i | :heavy_check_mark: | -l, --login | :no_good: |
 | -r | :no_good: | -s | :no_good: | -D | :no_good: |
 | [-+]O | :no_good: | -- | :no_good: | --debugger | :no_good: |
-| --dimp-po-strings | :no_good: | --help | :no_good: | --init-file | :no_good: |
+| --dimp-po-strings | :no_good: | --help | :heavy_check_mark: | --init-file | :no_good: |
 | --rcfile | :no_good: | --noediting | :no_good: | --noprofile | :no_good: |
 | --norc | :no_good: | --posix | :no_good: | --restricted | :no_good: |
 | -v, --verbose | :no_good: | --version | :heavy_check_mark: | -e | :heavy_check_mark: |

--- a/i18n/ar.ftl
+++ b/i18n/ar.ftl
@@ -1,5 +1,26 @@
 license = ترخيص
-text-version =
+version = إصدار
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     هذا برنامج مفتوح المصدر.
     يمكنك استخدامه وتعديله وإعادة توزيعه بحرية، سواء بالشيفرة المصدرية أو
     بشكل ثنائي، مع أو بدون تعديل، بشرط الحفاظ على إشعار حقوق النشر الأصلي

--- a/i18n/da.ftl
+++ b/i18n/da.ftl
@@ -1,5 +1,26 @@
 license = Licens
-text-version =
+version = version
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Dette er open source-software.
     Du er fri til at bruge, ændre og redistribuere denne software i kilde-
     eller binær form, med eller uden ændringer, forudsat at den originale

--- a/i18n/de.ftl
+++ b/i18n/de.ftl
@@ -1,5 +1,26 @@
 license = Lizenz
-text-version =
+version = Version
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Dies ist Open-Source-Software.
     Sie dürfen diese Software in Quell- oder Binärform frei verwenden,
     modifizieren und weiterverbreiten, mit oder ohne Änderungen,

--- a/i18n/el.ftl
+++ b/i18n/el.ftl
@@ -1,5 +1,26 @@
 license = Άδεια
-text-version =
+version = έκδοση
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Αυτό είναι λογισμικό ανοιχτού κώδικα.
     Είστε ελεύθεροι να χρησιμοποιείτε, να τροποποιείτε και να διανέμετε αυτό το λογισμικό
     σε μορφή πηγαίου ή δυαδικού κώδικα, με ή χωρίς τροποποιήσεις, υπό την προϋπόθεση

--- a/i18n/en.ftl
+++ b/i18n/en.ftl
@@ -1,5 +1,26 @@
 license = License
-text-version =
+version = version
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     This is open source software.
     You are free to use, modify, and redistribute this software in source
     or binary form, with or without modification, provided that the original

--- a/i18n/es.ftl
+++ b/i18n/es.ftl
@@ -1,5 +1,26 @@
 license = Licencia
-text-version =
+version = versión
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Este es un software de código abierto.
     Usted es libre de usar, modificar y redistribuir este software en forma
     fuente o binaria, con o sin modificaciones, siempre que el aviso de

--- a/i18n/fi.ftl
+++ b/i18n/fi.ftl
@@ -1,5 +1,26 @@
 license = Lisenssi
-text-version =
+version = versio
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Tämä on avoimen lähdekoodin ohjelmisto.
     Voit vapaasti käyttää, muokata ja levittää tätä ohjelmistoa
     lähde- tai binäärimuodossa, muutoksilla tai ilman, kunhan alkuperäinen

--- a/i18n/fr.ftl
+++ b/i18n/fr.ftl
@@ -1,5 +1,26 @@
 license = Licence
-text-version =
+version = version
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Ceci est un logiciel open source.
     Vous êtes libre d'utiliser, de modifier et de redistribuer ce logiciel
     sous forme source ou binaire, avec ou sans modification, à condition que

--- a/i18n/hi.ftl
+++ b/i18n/hi.ftl
@@ -1,5 +1,26 @@
 license = लाइसेंस
-text-version =
+version = संस्करण
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     यह एक ओपन सोर्स सॉफ़्टवेयर है।
     आप इस सॉफ़्टवेयर का उपयोग, संशोधन और पुनर्वितरण स्वतंत्र रूप से कर सकते हैं,
     स्रोत या बाइनरी रूप में, संशोधन के साथ या बिना, बशर्ते कि मूल

--- a/i18n/it.ftl
+++ b/i18n/it.ftl
@@ -1,5 +1,26 @@
 License = Licenza
-text-version =
+version = versione
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Questo è un software open source.
     Sei libero di usare, modificare e ridistribuire questo software in forma
     sorgente o binaria, con o senza modifiche, a condizione che

--- a/i18n/ja.ftl
+++ b/i18n/ja.ftl
@@ -1,5 +1,26 @@
 license = ライセンス
-text-version =
+version = バージョン
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     これはオープンソースソフトウェアです。
     このソフトウェアは、オリジナルの著作権表示、条件の一覧、
     免責事項が保持されている限り、ソースまたはバイナリ形式で、

--- a/i18n/ko.ftl
+++ b/i18n/ko.ftl
@@ -1,5 +1,26 @@
 License = 라이선스
-text-version =
+version = 버전
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     이것은 오픈 소스 소프트웨어입니다.
     원본 저작권 고지, 조건 목록 및 면책 조항이 유지되는 한,
     이 소프트웨어를 소스 또는 바이너리 형태로 수정하거나 하지 않고도

--- a/i18n/nl.ftl
+++ b/i18n/nl.ftl
@@ -1,5 +1,26 @@
 license = Licentie
-text-version =
+version = versie
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Dit is open-sourcesoftware.
     U bent vrij om deze software te gebruiken, aan te passen en opnieuw te verspreiden,
     in bron- of binaire vorm, met of zonder wijzigingen, op voorwaarde dat de originele

--- a/i18n/no.ftl
+++ b/i18n/no.ftl
@@ -1,5 +1,26 @@
 license = Lisens
-text-version =
+version = versjon
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Dette er åpen kildekode-programvare.
     Du står fritt til å bruke, endre og redistribuere denne programvaren,
     i kildekode eller binær form, med eller uten modifikasjoner,

--- a/i18n/pl.ftl
+++ b/i18n/pl.ftl
@@ -1,5 +1,26 @@
 license = Licencja
-text-version =
+version = wersja
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     To jest oprogramowanie open source.
     Możesz swobodnie używać, modyfikować i rozpowszechniać to oprogramowanie
     w formie źródłowej lub binarnej, z modyfikacjami lub bez, pod warunkiem

--- a/i18n/pt.ftl
+++ b/i18n/pt.ftl
@@ -1,5 +1,26 @@
 license = Licença
-text-version =
+version = versão
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Este é um software de código aberto.
     Você é livre para usar, modificar e redistribuir este software
     em forma de código-fonte ou binário, com ou sem modificações,

--- a/i18n/ru.ftl
+++ b/i18n/ru.ftl
@@ -1,5 +1,26 @@
 license = Лицензия
-text-version =
+version = версия
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Это программное обеспечение с открытым исходным кодом.
     Вы можете свободно использовать, изменять и распространять это программное обеспечение
     в исходной или двоичной форме, с изменениями или без, при условии сохранения

--- a/i18n/sl.ftl
+++ b/i18n/sl.ftl
@@ -1,5 +1,26 @@
 license = Licenca
-text-version =
+version = različica
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     To je programska oprema z odprto kodo.
     Prosto jo lahko uporabljate, spreminjate in razširjate v izvorni
     ali binarni obliki, s spremembami ali brez, pod pogojem, da se ohranijo

--- a/i18n/sv.ftl
+++ b/i18n/sv.ftl
@@ -1,5 +1,26 @@
 license = Licens
-text-version =
+version = version
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Detta är öppen källkodsprogramvara.
     Du är fri att använda, modifiera och distribuera denna programvara i källkod
     eller binär form, med eller utan ändringar, förutsatt att det ursprungliga

--- a/i18n/sw.ftl
+++ b/i18n/sw.ftl
@@ -1,5 +1,26 @@
 license = Leseni
-text-version =
+version = toleo
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Hii ni programu ya chanzo huria.
     Unaweza kuitumia, kuibadilisha, na kuisambaza tena kwa uhuru
     katika hali ya msimbo wa chanzo au iliyobainishwa, ukiwa umeifanyia

--- a/i18n/uk.ftl
+++ b/i18n/uk.ftl
@@ -1,5 +1,26 @@
 license = Ліцензія
-text-version =
+version = версія
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     Це програмне забезпечення з відкритим кодом.
     Ви можете вільно використовувати, змінювати та розповсюджувати це програмне забезпечення
     у вихідному або бінарному вигляді, з модифікаціями або без, за умови збереження

--- a/i18n/zh.ftl
+++ b/i18n/zh.ftl
@@ -1,4 +1,4 @@
-license = 授
+license = 授權
 version = 版本
 
 usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]

--- a/i18n/zh.ftl
+++ b/i18n/zh.ftl
@@ -1,5 +1,26 @@
-license = 授權
-text-version =
+license = 授
+version = 版本
+
+usage = Usage: sushi [LONG OPTIONS] [OPTIONS] [SCRIPT] [ARGS]
+
+long_options =
+    LONG OPTIONS:
+           --help               Show this help and exit
+           --version            Show version information and exit
+           
+shell_options =
+    Shell OPTIONS:
+           -c <command>         Execute <command> and exit
+           -o <option>          Enable the given shell option
+           +o <option>          Disable the given shell option
+           
+special_options =
+    Special OPTIONS:
+           --                   End of options; following args are positional
+           
+text_help = https://github.com/shellgei/rusty_bash
+
+text_version =
     本軟體為開放原始碼軟體。
     您可自由使用、修改及再散佈本軟體，
     不論是原始碼或二進位形式，無論是否修改，前提是保留

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,7 +339,7 @@ fn show_version() {
         env!("CARGO_PKG_VERSION"),
         env!("CARGO_BUILD_PROFILE"),
         fl("license"),
-        fl("text_version"),
+        fl("text_version")
     );
     process::exit(0);
 }
@@ -363,7 +363,7 @@ fn show_help() {
         fl("long_options"),
         fl("shell_options"),
         fl("special_options"),
-        fl("text_help"),
+        fl("text_help")
     );
     process::exit(0);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,11 @@ fn main() {
         return;
     }
 
+    if args.iter().any(|a| a == "--help") {
+        show_help();
+        return;
+    }
+
     let command = args.get(0).cloned().unwrap_or_else(|| "sush".to_string());
     let script_parts = consume_file_and_subsequents(&mut args);
 
@@ -315,22 +320,50 @@ fn fl(key: &str) -> String {
 
 fn show_message() {
     eprintln!(
-        "Rusty Bash (a.k.a. Sushi shell), version {} - {}",
+        "Rusty Bash (a.k.a. Sushi shell), {} {} - {}",
+        fl("version"),
         env!("CARGO_PKG_VERSION"),
         env!("CARGO_BUILD_PROFILE")
     );
 }
 
+
 fn show_version() {
     eprintln!(
-        "Rusty Bash (a.k.a. Sushi shell), version {} - {}\n\
+        "Rusty Bash (a.k.a. Sushi shell), {} {} - {}\n\
          © 2024 Ryuichi Ueda\n\
          {}: BSD 3-Clause\n\
          \n\
-         {}",
+         {}\n",
+        fl("version"),
         env!("CARGO_PKG_VERSION"),
         env!("CARGO_BUILD_PROFILE"),
-        fl("license"), fl("text-version")
+        fl("license"),
+        fl("text_version"),
+    );
+    process::exit(0);
+}
+
+fn show_help() {
+    eprintln!(
+        "Rusty Bash (a.k.a. Sushi shell), {} {} - {}\n\
+         {}\n\
+         \n\
+         {}:\n\
+         \n\
+         {}:\n\
+         \n\
+         {}:\n\
+         \n\
+         {}\n",
+        fl("version"),
+        env!("CARGO_PKG_VERSION"),
+        env!("CARGO_BUILD_PROFILE"),
+        fl("usage"),
+        fl("long_options"),
+        fl("shell_options"),
+        fl("special_options"),
+        fl("text_help"),
     );
     process::exit(0);
 }


### PR DESCRIPTION
This adds --help support.

If I can get a list of all the options that should be included, I'll add them.
After that, I plan to translate everything as well, and probably improve it even further.

The version string is now also handled through Fluent.
