### PR TITLE
Compile-time language support + Name change + Panic abort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,28 @@ locale_config = "0.3"
 
 # Compile-time feature
 [features]
-lang_ar = [] ; lang_da = [] ; lang_de = [] ; lang_el = [] ; lang_en = []
-lang_es = [] ; lang_fi = [] ; lang_fr = [] ; lang_hi = [] ; lang_it = []
-lang_ja = [] ; lang_ko = [] ; lang_nl = [] ; lang_no = [] ; lang_pl = []
-lang_pt = [] ; lang_ru = [] ; lang_sl = [] ; lang_sv = [] ; lang_sw = []
-lang_uk = [] ; lang_zh = []
+lang_ar = []
+lang_da = []
+lang_de = []
+lang_el = []
+lang_en = []
+lang_es = []
+lang_fi = []
+lang_fr = []
+lang_hi = []
+lang_it = []
+lang_ja = []
+lang_ko = []
+lang_nl = []
+lang_no = []
+lang_pl = []
+lang_pt = []
+lang_ru = []
+lang_sl = []
+lang_sv = []
+lang_sw = []
+lang_uk = []
+lang_zh = []
 
 default = ["0", "1", "2", "3", "4", "5", "6"]               # All
 0 = ["lang_en", "lang_fr", "lang_ja"]                       # Dev Pack

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ fluent-bundle = "0.16"
 unic-langid = "0.9"
 once_cell = "1"
 locale_config = "0.3"
-widestring = "1.2.0"
 
 [profile.release]
 opt-level = 3
 codegen-units = 1
 lto = true
+panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,30 @@ rand_chacha = { version = "0.9.0", features = [ "os_rng" ]}
 time = "0.3"
 sprintf = "0.4"
 
-#Internationalization
+# Internationalization
 fluent-bundle = "0.16"
 unic-langid = "0.9"
 once_cell = "1"
 locale_config = "0.3"
+
+
+# Compile-time feature
+[features]
+lang_ar = [] ; lang_da = [] ; lang_de = [] ; lang_el = [] ; lang_en = []
+lang_es = [] ; lang_fi = [] ; lang_fr = [] ; lang_hi = [] ; lang_it = []
+lang_ja = [] ; lang_ko = [] ; lang_nl = [] ; lang_no = [] ; lang_pl = []
+lang_pt = [] ; lang_ru = [] ; lang_sl = [] ; lang_sv = [] ; lang_sw = []
+lang_uk = [] ; lang_zh = []
+
+default = ["0", "1", "2", "3", "4", "5", "6"]               # All
+0 = ["lang_en", "lang_fr", "lang_ja"]                       # Dev Pack
+1 = ["0", "lang_es", "lang_fr", "lang_it", "lang_pt"]       # Latin
+2 = ["0", "lang_nl", "lang_de", "lang_sl", "lang_el"]       # Central Europe
+3 = ["0", "lang_da", "lang_fi", "lang_no", "lang_sv"]       # Northern Europe
+4 = ["0", "lang_ru", "lang_uk", "lang_pl"]                  # Eastern Europe
+5 = ["0", "lang_hi", "lang_ja", "lang_ko", "lang_zh"]       # Asia
+6 = ["0", "lang_ar", "lang_sw"]                             # Africa / Middle East
+
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rusty Bash (a.k.a. sushi 🍣 shell)
+# Sushi shell (a.k.a. 🍣 Sush)
 
 
 [![ubuntu-latest](https://github.com/shellgei/rusty_bash/actions/workflows/ubuntu.yml/badge.svg)](https://github.com/shellgei/rusty_bash/actions/workflows/ubuntu.yml)
@@ -61,7 +61,7 @@ The following behavior of Bash will not be imitated by `sush`. So we alter the r
     -9223372036854775808                    #IT'S WRONG. 
     $ echo $(( -9223372036854775807 * -1 )) #IT'S OK.
     9223372036854775807
-    ### Rusty Bash ###
+    ### Sushi shell ###
     🍣 echo $(( -9223372036854775808 * -1 ))
     9223372036854775808
     🍣 echo $(( -9223372036854775807 * -1 ))

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,3 +1,6 @@
+//SPDX-FileCopyrightText: 2022 Ryuichi Ueda ryuichiueda@gmail.com
+//SPDX-License-Identifier: BSD-3-Clause
+
 ///// Internationalization with Fluent and system language detection /////
 
 use once_cell::unsync::OnceCell;

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,0 +1,169 @@
+///// Internationalization with Fluent and system language detection /////
+
+use once_cell::unsync::OnceCell;
+use fluent_bundle::{FluentBundle, FluentResource};
+use std::thread_local;
+use unic_langid::LanguageIdentifier;
+
+thread_local! {
+    pub static FLUENT_BUNDLE: OnceCell<FluentBundle<FluentResource>> = OnceCell::new();
+}
+
+#[cfg(feature = "lang_ar")]
+pub static FTL_AR: &str = include_str!("../i18n/ar.ftl");
+#[cfg(feature = "lang_da")]
+pub static FTL_DA: &str = include_str!("../i18n/da.ftl");
+#[cfg(feature = "lang_de")]
+pub static FTL_DE: &str = include_str!("../i18n/de.ftl");
+#[cfg(feature = "lang_el")]
+pub static FTL_EL: &str = include_str!("../i18n/el.ftl");
+#[cfg(feature = "lang_en")]
+pub static FTL_EN: &str = include_str!("../i18n/en.ftl");
+#[cfg(feature = "lang_es")]
+pub static FTL_ES: &str = include_str!("../i18n/es.ftl");
+#[cfg(feature = "lang_fi")]
+pub static FTL_FI: &str = include_str!("../i18n/fi.ftl");
+#[cfg(feature = "lang_fr")]
+pub static FTL_FR: &str = include_str!("../i18n/fr.ftl");
+#[cfg(feature = "lang_hi")]
+pub static FTL_HI: &str = include_str!("../i18n/hi.ftl");
+#[cfg(feature = "lang_it")]
+pub static FTL_IT: &str = include_str!("../i18n/it.ftl");
+#[cfg(feature = "lang_ja")]
+pub static FTL_JA: &str = include_str!("../i18n/ja.ftl");
+#[cfg(feature = "lang_ko")]
+pub static FTL_KO: &str = include_str!("../i18n/ko.ftl");
+#[cfg(feature = "lang_nl")]
+pub static FTL_NL: &str = include_str!("../i18n/nl.ftl");
+#[cfg(feature = "lang_no")]
+pub static FTL_NO: &str = include_str!("../i18n/no.ftl");
+#[cfg(feature = "lang_pl")]
+pub static FTL_PL: &str = include_str!("../i18n/pl.ftl");
+#[cfg(feature = "lang_pt")]
+pub static FTL_PT: &str = include_str!("../i18n/pt.ftl");
+#[cfg(feature = "lang_ru")]
+pub static FTL_RU: &str = include_str!("../i18n/ru.ftl");
+#[cfg(feature = "lang_sl")]
+pub static FTL_SL: &str = include_str!("../i18n/sl.ftl");
+#[cfg(feature = "lang_sv")]
+pub static FTL_SV: &str = include_str!("../i18n/sv.ftl");
+#[cfg(feature = "lang_sw")]
+pub static FTL_SW: &str = include_str!("../i18n/sw.ftl");
+#[cfg(feature = "lang_uk")]
+pub static FTL_UK: &str = include_str!("../i18n/uk.ftl");
+#[cfg(feature = "lang_zh")]
+pub static FTL_ZH: &str = include_str!("../i18n/zh.ftl");
+
+struct LangEntry {
+    code: &'static str,
+    #[allow(dead_code)]
+    #[cfg(any(
+        feature = "lang_ar", feature = "lang_da", feature = "lang_de", feature = "lang_el",
+        feature = "lang_en", feature = "lang_es", feature = "lang_fi", feature = "lang_fr",
+        feature = "lang_hi", feature = "lang_it", feature = "lang_ja", feature = "lang_ko",
+        feature = "lang_nl", feature = "lang_no", feature = "lang_pl", feature = "lang_pt",
+        feature = "lang_ru", feature = "lang_sl", feature = "lang_sv", feature = "lang_sw",
+        feature = "lang_uk", feature = "lang_zh"
+    ))]
+    ftl: &'static str,
+}
+
+const LANGS: &[LangEntry] = &[
+    #[cfg(feature = "lang_ar")]
+    LangEntry { code: "ar", ftl: FTL_AR },
+    #[cfg(feature = "lang_da")]
+    LangEntry { code: "da", ftl: FTL_DA },
+    #[cfg(feature = "lang_de")]
+    LangEntry { code: "de", ftl: FTL_DE },
+    #[cfg(feature = "lang_el")]
+    LangEntry { code: "el", ftl: FTL_EL },
+    #[cfg(feature = "lang_en")]
+    LangEntry { code: "en", ftl: FTL_EN },
+    #[cfg(feature = "lang_es")]
+    LangEntry { code: "es", ftl: FTL_ES },
+    #[cfg(feature = "lang_fi")]
+    LangEntry { code: "fi", ftl: FTL_FI },
+    #[cfg(feature = "lang_fr")]
+    LangEntry { code: "fr", ftl: FTL_FR },
+    #[cfg(feature = "lang_hi")]
+    LangEntry { code: "hi", ftl: FTL_HI },
+    #[cfg(feature = "lang_it")]
+    LangEntry { code: "it", ftl: FTL_IT },
+    #[cfg(feature = "lang_ja")]
+    LangEntry { code: "ja", ftl: FTL_JA },
+    #[cfg(feature = "lang_ko")]
+    LangEntry { code: "ko", ftl: FTL_KO },
+    #[cfg(feature = "lang_nl")]
+    LangEntry { code: "nl", ftl: FTL_NL },
+    #[cfg(feature = "lang_no")]
+    LangEntry { code: "no", ftl: FTL_NO },
+    #[cfg(feature = "lang_pl")]
+    LangEntry { code: "pl", ftl: FTL_PL },
+    #[cfg(feature = "lang_pt")]
+    LangEntry { code: "pt", ftl: FTL_PT },
+    #[cfg(feature = "lang_ru")]
+    LangEntry { code: "ru", ftl: FTL_RU },
+    #[cfg(feature = "lang_sl")]
+    LangEntry { code: "sl", ftl: FTL_SL },
+    #[cfg(feature = "lang_sv")]
+    LangEntry { code: "sv", ftl: FTL_SV },
+    #[cfg(feature = "lang_sw")]
+    LangEntry { code: "sw", ftl: FTL_SW },
+    #[cfg(feature = "lang_uk")]
+    LangEntry { code: "uk", ftl: FTL_UK },
+    #[cfg(feature = "lang_zh")]
+    LangEntry { code: "zh", ftl: FTL_ZH },
+];
+
+pub fn get_system_language() -> String {
+    fn extract_lang(s: &str) -> Option<String> {
+        let first_part = s.split(&['_', '.']).next()?;
+        if first_part.is_empty() {
+            None
+        } else {
+            Some(first_part.to_string())
+        }
+    }
+
+    for var in &["LC_ALL", "LC_MESSAGES", "LANG"] {
+        if let Ok(val) = std::env::var(var) {
+            if let Some(lang) = extract_lang(&val) {
+                return lang;
+            }
+        }
+    }
+
+    "en".to_string()
+}
+
+pub fn load_fluent_bundle() -> Option<FluentBundle<FluentResource>> {
+    let lang = get_system_language();
+
+    let entry = LANGS
+        .iter()
+        .find(|e| e.code == lang)
+        .or_else(|| LANGS.iter().find(|e| e.code == "en"))?;
+
+
+    let res = FluentResource::try_new(entry.ftl.to_string()).ok()?;
+    let langid: LanguageIdentifier = entry.code.parse().ok()?;
+    let mut bundle = FluentBundle::new(vec![langid]);
+    bundle.add_resource(res).ok()?;
+
+    Some(bundle)
+}
+
+pub fn fl(key: &str) -> String {
+    FLUENT_BUNDLE.with(|cell| {
+        let bundle = cell.get_or_init(|| {
+            load_fluent_bundle().expect("Could not load translation bundle")
+        });
+
+        let mut errors = vec![];
+        bundle
+            .get_message(key)
+            .and_then(|msg| msg.value())
+            .map(|pattern| bundle.format_pattern(pattern, None, &mut errors).to_string())
+            .unwrap_or_else(|| format!("{{{}}}", key))
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,7 +276,7 @@ fn set_history(core: &mut ShellCore, s: &str) {
 
 fn show_message() {
     eprintln!(
-        "Rusty Bash (a.k.a. Sushi Sush), {} {} - {}",
+        "Sushi shell (a.k.a. Sush), {} {} - {}",
         fl("version"),
         env!("CARGO_PKG_VERSION"),
         env!("CARGO_BUILD_PROFILE")

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,7 +201,7 @@ fn main_loop(core: &mut ShellCore, command: &String) {
         show_message();
     }
 
-    loop {                    
+    loop {
         match feed_script(&mut feeder, core) {
             (true, false) => {},
             (false, true) => break,

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,15 +288,15 @@ fn get_system_language() -> String {
     "en".to_string()
 }
 
-fn load_fluent_bundle(lang: &str) -> FluentBundle<FluentResource> {
-    let langid: LanguageIdentifier = lang.parse().unwrap_or_else(|_| "en".parse().unwrap());
-    let ftl_string = fs::read_to_string(format!("i18n/{}.ftl", lang))
-        .unwrap_or("license = License\ntext-version =\n    This is open source software.\n    You are free to use, modify, and redistribute this software in source\n    or binary form, with or without modification, provided that the original\n    copyright notice, list of conditions, and disclaimer are retained.\n    THIS SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n    EXPRESS OR IMPLIED, TO THE EXTENT PERMITTED BY LAW.".to_string());
-
-    let resource = FluentResource::try_new(ftl_string).expect("Invalid FTL syntax");
-    let mut bundle = FluentBundle::new(vec![langid]);
-    bundle.add_resource(resource).expect("Failed to add resource");
-    bundle
+fn load_fluent_bundle(lang: &str) -> FluentBundle<FluentResource> {                     // Do not hardcode fallback strings here; get_system_language already uses en.ftl as a fallback.
+    let langid: LanguageIdentifier = lang.parse().unwrap();                             // If the language is not supported, en.ftl will be used by default; adding another fallback here is not necessary and messy.
+    let ftl_string = fs::read_to_string(format!("i18n/{}.ftl", lang))                   // If the language is supported but a specific string is not translated, (fluent-key) will be shown.
+        .or_else(|_| fs::read_to_string("i18n/en.ftl"))                                 // If the language is supported, hardcoded strings here won’t fill any missing keys — by design.
+        .expect("No suitable .ftl file found");                                         // If either fn get_system_language or fn load_fluent_bundle fail; en.ftl will be used by default.
+    let resource = FluentResource::try_new(ftl_string).expect("Invalid FTL syntax");    // All missing strings will show visibly; as translations come from one single source file.
+    let mut bundle = FluentBundle::new(vec![langid]);                                   // Changing this logic might hide missing translations or bugs.
+    bundle.add_resource(resource).expect("Failed to add resource");                     // TODO: Selecting the wanted .ftl files at compilation; en.ftl will be included in the binary by default.
+    bundle                                                                              // Provide maximum reliability, portability and safety (anti-tempering) while optimizing the overall size.
 }
 
 fn fl(key: &str) -> String {
@@ -320,7 +320,7 @@ fn fl(key: &str) -> String {
 
 fn show_message() {
     eprintln!(
-        "Rusty Bash (a.k.a. Sushi shell), {} {} - {}",
+        "Rusty Bash (a.k.a. Sushi Sush), {} {} - {}",
         fl("version"),
         env!("CARGO_PKG_VERSION"),
         env!("CARGO_BUILD_PROFILE")
@@ -329,7 +329,7 @@ fn show_message() {
 
 fn show_version() {
     eprintln!(
-        "Rusty Bash (a.k.a. Sushi shell), {} {} - {}\n\
+        "Sushi shell (a.k.a. Sush), {} {} - {}\n\
          © 2024 Ryuichi Ueda\n\
          {}: BSD 3-Clause\n\
          \n\
@@ -344,7 +344,7 @@ fn show_version() {
 }
 
 fn show_help() {
-    eprintln!("Rusty Bash (a.k.a. Sushi shell), {} {} - {}\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n\n{}",
+    eprintln!("Sushi shell (a.k.a. Sush), {} {} - {}\n\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n\n{}",
     fl("version"),
     env!("CARGO_PKG_VERSION"),
     env!("CARGO_BUILD_PROFILE"),


### PR DESCRIPTION
So in this PR:

1.     I officially replace Rusty Bash’s name with Sushi Shell.

Like I said before, Sushi is a good name, and I think we can abandon Rusty Bash.
Is this nothing more than a Bash clone? That’s a branding problem.
Plus, the fact that we're actively using three names is confusing: one full name in the documentation, one repo/directory name, and one for the binary we actually use.

Even if you agree with this PR, I cannot rename the repo to Sushi — only you can.
Then you’ll have to rename the rest in README.md.

But I’ve also:

2.     Added panic = "abort" in Cargo.toml: This is a RELEASE-only optimization to reduce the binary size. 
       There’s no safety drawback, bug introduced, or anything else. But if a panic occurs in a release version, 
       Sushi will close immediately. In some way, it will behave like any app written in C. I just thought it might 
       be a good move for a shell that aims to be light and simple.

3.     Removed widestring from dependencies — I don't know why it ended up in there.

4.     I’ve restored (pretty much) my version of fn load_fluent_bundle, but I added a lot of comments 
       explaining why it’s good code, why it’s safe, and the next goal are for that feature.

Edit: I also added:

5.     A compile-time language feature for selecting supported languages.
 