### PR TITLE
Drop Regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ signal-hook = "0.3.17"
 rev_lines = "0.3.0"
 faccess = "0.2.4"
 io-streams = "0.16.3"
-regex = "1.11.1"
 rand = "0.9"
 rand_chacha = { version = "0.9.0", features = [ "os_rng" ]}
 time = "0.3"

--- a/src/elements/subword.rs
+++ b/src/elements/subword.rs
@@ -21,6 +21,7 @@ mod process_sub;
 use crate::{ShellCore, Feeder};
 use crate::error::{exec::ExecError, parse::ParseError};
 use crate::elements::word::WordMode;
+use crate::regex;
 use crate::utils::splitter;
 use self::ansi_c_quoted::AnsiCQuoted;
 use self::arithmetic::Arithmetic;
@@ -95,7 +96,7 @@ pub trait Subword {
     fn make_regex(&mut self) -> Option<String> {
         match self.get_text() {
             "" => None,
-            s  => Some(s.to_string()),
+            s  => Some(regex::shell_pattern_to_regex(s)),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod error;
 mod feeder;
 mod elements;
 mod main_c_option;
+mod regex;
 mod signal;
 mod proc_ctrl;
 mod utils;

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,0 +1,53 @@
+//SPDX-FileCopyrightText: 2025 Hugo Fortin
+//SPDX-License-Identifier: BSD-3-Clause
+
+///// Custom and ultra-light Regex implementation /////
+
+pub fn glob_to_regex(pattern: &str) -> String {
+    let mut regex = String::from("^");
+    let mut chars = pattern.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '*' => regex.push_str(".*"),
+            '?' => regex.push('.'),
+            '.' => regex.push_str(r"\."),
+            '[' => {
+                regex.push('[');
+                if let Some(&next_ch) = chars.peek() {
+                    if next_ch == '!' || next_ch == '^' {
+                        regex.push('^');
+                        chars.next();
+                    }
+                }
+                while let Some(c) = chars.next() {
+                    regex.push(c);
+                    if c == ']' {
+                        break;
+                    }
+                }
+            }
+            '\\' => regex.push_str(r"\\"),
+            c if is_metachar(c) => {
+                regex.push('\\');
+                regex.push(c);
+            }
+            c => regex.push(c),
+        }
+    }
+
+    regex.push('$');
+    regex
+}
+
+fn is_metachar(c: char) -> bool {
+    matches!(c, '^' | '$' | '.' | '+' | '(' | ')' | '|' | '{' | '}' | '\\')
+}
+
+pub fn shell_pattern_to_regex(pattern: &str) -> String {
+    glob_to_regex(pattern)
+}
+
+pub fn naive_glob_match(text: &str, regex: &str) -> bool {
+    text == regex.trim_start_matches('^').trim_end_matches('$')
+}


### PR DESCRIPTION
I’ve decided that we can drop Regex as a dependency.
In fact, we need very little functionality from it.

This PR introduces regex.rs, a custom implementation to replace the crate, as I believe the risk is negligible.

With this change, the compiled release binary size goes from 3976 KB down to 2440 KB —
**a reduction of 1536 KB, or 38.6%.**

From my testing, it works flawlessly.

You are very welcome :sunglasses: