### PR TITLE
Fix clippy

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,14 +6,14 @@ use std::env;
 fn main() {
     // BASH_VERSION, BASH_VERSINFO[4]
     let profile = env::var("PROFILE").unwrap_or("".to_string());
-    println!("cargo:rustc-env=CARGO_BUILD_PROFILE={}", profile);
+    println!("cargo:rustc-env=CARGO_BUILD_PROFILE={profile}");
     // HOSTTYPE, MACHTYPE, BASH_VERSINFO[5]
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or("unknown".to_string());
-    println!("cargo:rustc-env=CARGO_CFG_TARGET_ARCH={}", target_arch);
+    println!("cargo:rustc-env=CARGO_CFG_TARGET_ARCH={target_arch}");
     // MACHTYPE, BASH_VERSINFO[5]
     let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap_or("unknown".to_string());
-    println!("cargo:rustc-env=CARGO_CFG_TARGET_VENDOR={}", target_vendor);
+    println!("cargo:rustc-env=CARGO_CFG_TARGET_VENDOR={target_vendor}");
     // OSTYPE, MACHTYPE, BASH_VERSINFO[5]
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or("unknown".to_string());    
-    println!("cargo:rustc-env=CARGO_CFG_TARGET_OS={}", target_os);
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or("unknown".to_string());
+    println!("cargo:rustc-env=CARGO_CFG_TARGET_OS={target_os}");
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -9,34 +9,37 @@ pub mod history;
 pub mod jobtable;
 pub mod options;
 
-use crate::{error, proc_ctrl, signal};
-use crate::elements::substitution::Substitution;
+use self::completion::{Completion, CompletionEntry};
 use self::database::DataBase;
 use self::options::Options;
-use self::completion::{Completion, CompletionEntry};
-use std::collections::HashMap;
-use std::os::fd::{FromRawFd, OwnedFd};
-use std::{io, env, path};
-use nix::{fcntl, unistd};
+use crate::core::jobtable::JobEntry;
+use crate::elements::substitution::Substitution;
+use crate::{error, proc_ctrl, signal};
 use nix::sys::signal::Signal;
 use nix::sys::time::{TimeSpec, TimeVal};
 use nix::unistd::Pid;
-use crate::core::jobtable::JobEntry;
-use std::sync::Arc;
+use nix::{fcntl, unistd};
+use std::collections::HashMap;
+use std::os::fd::{FromRawFd, OwnedFd};
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+type BuiltinFn = fn(&mut ShellCore, &[String]) -> i32;
+type SubstBuiltinFn = fn(&mut ShellCore, &[String], &mut [Substitution]) -> i32;
+use std::{env, io, path};
 
 pub struct MeasuredTime {
-    pub real: TimeSpec, 
-    pub user: TimeVal, 
-    pub sys: TimeVal, 
+    pub real: TimeSpec,
+    pub user: TimeVal,
+    pub sys: TimeVal,
 }
 
 impl Default for MeasuredTime {
     fn default() -> Self {
         Self {
-            real: TimeSpec::new(0,0),
-            user: TimeVal::new(0,0),
-            sys: TimeVal::new(0,0),
+            real: TimeSpec::new(0, 0),
+            user: TimeVal::new(0, 0),
+            sys: TimeVal::new(0, 0),
         }
     }
 }
@@ -48,8 +51,8 @@ pub struct ShellCore {
     pub alias_memo: Vec<(String, String)>,
     pub rewritten_history: HashMap<usize, String>,
     pub history: Vec<String>,
-    pub builtins: HashMap<String, fn(&mut ShellCore, &mut Vec<String>) -> i32>,
-    pub substitution_builtins: HashMap<String, fn(&mut ShellCore, &mut Vec<String>, &mut Vec<Substitution>) -> i32>,
+    pub builtins: HashMap<String, BuiltinFn>,
+    pub substitution_builtins: HashMap<String, SubstBuiltinFn>,
     pub sigint: Arc<AtomicBool>,
     pub trapped: Vec<(Arc<AtomicBool>, String)>,
     pub traplist: Vec<(i32, String)>,
@@ -92,28 +95,27 @@ impl ShellCore {
             let _ = self.db.set_param("PS2", "> ", None);
             let fd = fcntl::fcntl(0, fcntl::F_DUPFD_CLOEXEC(255))
                 .expect("sush(fatal): Can't allocate fd for tty FD");
-            self.tty_fd = Some(unsafe{OwnedFd::from_raw_fd(fd)});
-        }else{
+            self.tty_fd = Some(unsafe { OwnedFd::from_raw_fd(fd) });
+        } else {
             self.db.flags += "h";
         }
 
-        let home = self.db.get_param("HOME").unwrap_or(String::new()).to_string();
-        let _ = self.db.set_param("HISTFILE", &(home + "/.sush_history"), None);
+        let home = self.db.get_param("HOME").unwrap_or_default().to_string();
+        let _ = self
+            .db
+            .set_param("HISTFILE", &(home + "/.sush_history"), None);
         let _ = self.db.set_param("HISTFILESIZE", "2000", None);
 
-        match env::var("SUSH_COMPAT_TEST_MODE").as_deref() {
-            Ok("1") => {
-                if self.db.flags.contains('i') {
-                    eprintln!("THIS IS BASH COMPATIBILITY TEST MODE");
-                }
-                self.compat_bash = true;
-            },
-            _ => {},
+        if let Ok("1") = env::var("SUSH_COMPAT_TEST_MODE").as_deref() {
+            if self.db.flags.contains('i') {
+                eprintln!("THIS IS BASH COMPATIBILITY TEST MODE");
+            }
+            self.compat_bash = true;
         };
     }
 
     pub fn new() -> Self {
-        ShellCore{
+        ShellCore {
             db: DataBase::new(),
             sigint: Arc::new(AtomicBool::new(false)),
             options: Options::new_as_basic_opts(),
@@ -127,7 +129,7 @@ impl ShellCore {
         if unistd::isatty(0) == Ok(true) {
             let fd = fcntl::fcntl(0, fcntl::F_DUPFD_CLOEXEC(255))
                 .expect("sush(fatal): Can't allocate fd for tty FD");
-            self.tty_fd = Some(unsafe{OwnedFd::from_raw_fd(fd)});
+            self.tty_fd = Some(unsafe { OwnedFd::from_raw_fd(fd) });
         }
 
         self.init_current_directory();
@@ -136,9 +138,8 @@ impl ShellCore {
         signal::ignore(Signal::SIGPIPE);
         signal::ignore(Signal::SIGTSTP);
 
-        match env::var("SUSH_COMPAT_TEST_MODE").as_deref() {
-            Ok("1") => self.compat_bash = true,
-            _ => {},
+        if let Ok("1") = env::var("SUSH_COMPAT_TEST_MODE").as_deref() {
+            self.compat_bash = true
         };
     }
 
@@ -148,18 +149,25 @@ impl ShellCore {
         let t_arch = env!("CARGO_CFG_TARGET_ARCH");
         let t_vendor = env!("CARGO_CFG_TARGET_VENDOR");
         let t_os = env!("CARGO_CFG_TARGET_OS");
-        let machtype = format!("{}-{}-{}", t_arch, t_vendor, t_os);
+        let machtype = format!("{t_arch}-{t_vendor}-{t_os}");
         let symbol = "rusty_bash";
         let vparts = version.split('.').collect();
-        let versinfo = [vparts, vec![symbol, profile, &machtype]].concat()
-                       .iter().map(|e| e.to_string()).collect();
+        let versinfo = [vparts, vec![symbol, profile, &machtype]]
+            .concat()
+            .iter()
+            .map(|e| e.to_string())
+            .collect();
 
-        let _ = self.db.set_param("BASH_VERSION", &format!("{}({})-{}", version, symbol, profile), None);
+        let _ = self.db.set_param(
+            "BASH_VERSION",
+            &format!("{version}({symbol})-{profile}"),
+            None,
+        );
         let _ = self.db.set_param("MACHTYPE", &machtype, None);
-        let _ = self.db.set_param("HOSTTYPE", &t_arch, None);
-        let _ = self.db.set_param("OSTYPE", &t_os, None);
+        let _ = self.db.set_param("HOSTTYPE", t_arch, None);
+        let _ = self.db.set_param("OSTYPE", t_os, None);
         let _ = self.db.set_array("BASH_VERSINFO", Some(versinfo), None);
-        let _ = self.db.set_flag("BASH_VERSINFO", 'r');
+        self.db.set_flag("BASH_VERSINFO", 'r');
     }
 
     pub fn flip_exit_status(&mut self) {
@@ -170,13 +178,15 @@ impl ShellCore {
         let pid = nix::unistd::getpid();
         self.db.init_as_num("BASHPID", &pid.to_string(), Some(0))?;
         match self.db.get_param("BASH_SUBSHELL").unwrap().parse::<usize>() {
-            Ok(num) => self.db.set_param("BASH_SUBSHELL", &(num+1).to_string(), Some(0))?,
-            Err(_) =>  self.db.set_param("BASH_SUBSHELL", "0", Some(0))?,
+            Ok(num) => self
+                .db
+                .set_param("BASH_SUBSHELL", &(num + 1).to_string(), Some(0))?,
+            Err(_) => self.db.set_param("BASH_SUBSHELL", "0", Some(0))?,
         }
         Ok(())
     }
 
-    pub fn initialize_as_subshell(&mut self, pid: Pid, pgid: Pid){
+    pub fn initialize_as_subshell(&mut self, pid: Pid, pgid: Pid) {
         signal::restore(Signal::SIGINT);
         signal::restore(Signal::SIGTSTP);
         signal::restore(Signal::SIGPIPE);
@@ -193,9 +203,9 @@ impl ShellCore {
         match env::current_dir() {
             Ok(path) => self.current_dir = Some(path),
             Err(err) => {
-                let msg = format!("pwd: error retrieving current directory: {:?}", err);
+                let msg = format!("pwd: error retrieving current directory: {err:?}");
                 error::print(&msg, self);
-            },
+            }
         }
     }
 
@@ -206,7 +216,6 @@ impl ShellCore {
         self.current_dir.clone()
     }
 
-
     pub fn set_current_directory(&mut self, path: &path::PathBuf) -> Result<(), io::Error> {
         env::set_current_dir(path)?;
         self.current_dir = Some(path.clone());
@@ -214,7 +223,12 @@ impl ShellCore {
     }
 
     pub fn get_ps4(&mut self) -> String {
-        let ps4 = self.db.get_param("PS4").unwrap_or_default().trim_end().to_string();
+        let ps4 = self
+            .db
+            .get_param("PS4")
+            .unwrap_or_default()
+            .trim_end()
+            .to_string();
         let mut multi_ps4 = ps4.to_string();
         for _ in 0..(self.source_files.len() as i32 + self.eval_level) {
             multi_ps4 += &ps4;
@@ -227,23 +241,21 @@ impl ShellCore {
         let before = word.clone();
         match self.replace_alias_core(word) {
             true => {
-                self.alias_memo.push( (before, word.clone()) );
+                self.alias_memo.push((before, word.clone()));
                 true
-            },
+            }
             false => false,
         }
     }
 
     fn replace_alias_core(&self, word: &mut String) -> bool {
-        if ! self.shopts.query("expand_aliases") {
-            if ! self.db.flags.contains('i') {
-                return false;
-            }
+        if !self.shopts.query("expand_aliases") && !self.db.flags.contains('i') {
+            return false;
         }
 
         let mut ans = false;
         let mut prev_head = "".to_string();
-        let history = vec![word.clone()];
+        let history = [word.clone()];
 
         loop {
             let head = match word.replace("\n", " ").split(' ').nth(0) {
@@ -254,7 +266,7 @@ impl ShellCore {
             if prev_head == head {
                 return ans;
             }
-    
+
             if let Some(value) = self.aliases.get(&head) {
                 *word = word.replacen(&head, value, 1);
                 if history.contains(word) {

--- a/src/core/builtins.rs
+++ b/src/core/builtins.rs
@@ -4,34 +4,34 @@
 
 mod alias;
 mod cd;
+mod command;
 pub mod compgen;
 pub mod complete;
 mod compopt;
-mod command;
 mod exec;
 mod getopts;
 mod hash;
 mod history;
 mod job_commands;
-pub mod parameter;
+mod loop_control;
 pub mod option;
+pub mod parameter;
 mod printf;
 mod pwd;
 mod read;
 pub mod source;
 mod trap;
 mod type_;
-mod loop_control;
 mod unset;
 
-use crate::{exit, Feeder, Script, ShellCore};
 use crate::elements::expr::arithmetic::ArithmeticExpr;
+use crate::{exit, Feeder, Script, ShellCore};
 
 pub fn error_exit(exit_status: i32, name: &str, msg: &str, core: &mut ShellCore) -> i32 {
     let shellname = core.db.get_param("0").unwrap();
     if core.db.flags.contains('i') {
         eprintln!("{}: {}: {}", &shellname, name, msg);
-    }else{
+    } else {
         let lineno = core.db.get_param("LINENO").unwrap_or("".to_string());
         eprintln!("{}: line {}: {}: {}", &shellname, &lineno, name, msg);
     }
@@ -44,31 +44,42 @@ impl ShellCore {
         self.builtins.insert("alias".to_string(), alias::alias);
         self.builtins.insert("bg".to_string(), job_commands::bg);
         self.builtins.insert("bind".to_string(), bind);
-        self.builtins.insert("break".to_string(), loop_control::break_);
-        self.builtins.insert("builtin".to_string(), command::builtin);
+        self.builtins
+            .insert("break".to_string(), loop_control::break_);
+        self.builtins
+            .insert("builtin".to_string(), command::builtin);
         self.builtins.insert("cd".to_string(), cd::cd);
-        self.builtins.insert("command".to_string(), command::command);
-        self.builtins.insert("compgen".to_string(), compgen::compgen);
-        self.builtins.insert("complete".to_string(), complete::complete);
-        self.builtins.insert("compopt".to_string(), compopt::compopt);
-        self.builtins.insert("continue".to_string(), loop_control::continue_);
+        self.builtins
+            .insert("command".to_string(), command::command);
+        self.builtins
+            .insert("compgen".to_string(), compgen::compgen);
+        self.builtins
+            .insert("complete".to_string(), complete::complete);
+        self.builtins
+            .insert("compopt".to_string(), compopt::compopt);
+        self.builtins
+            .insert("continue".to_string(), loop_control::continue_);
         self.builtins.insert("debug".to_string(), debug);
-        self.builtins.insert("disown".to_string(), job_commands::disown);
+        self.builtins
+            .insert("disown".to_string(), job_commands::disown);
         self.builtins.insert("eval".to_string(), eval);
         self.builtins.insert("exec".to_string(), exec::exec);
         self.builtins.insert("exit".to_string(), exit);
         self.builtins.insert("false".to_string(), false_);
         self.builtins.insert("fg".to_string(), job_commands::fg);
-        self.builtins.insert("getopts".to_string(), getopts::getopts);
+        self.builtins
+            .insert("getopts".to_string(), getopts::getopts);
         self.builtins.insert("hash".to_string(), hash::hash);
-        self.builtins.insert("history".to_string(), history::history);
+        self.builtins
+            .insert("history".to_string(), history::history);
         self.builtins.insert("jobs".to_string(), job_commands::jobs);
         self.builtins.insert("kill".to_string(), job_commands::kill);
         self.builtins.insert("let".to_string(), let_);
         self.builtins.insert("printf".to_string(), printf::printf);
         self.builtins.insert("pwd".to_string(), pwd::pwd);
         self.builtins.insert("read".to_string(), read::read);
-        self.builtins.insert("return".to_string(), loop_control::return_);
+        self.builtins
+            .insert("return".to_string(), loop_control::return_);
         self.builtins.insert("set".to_string(), option::set);
         self.builtins.insert("trap".to_string(), trap::trap);
         self.builtins.insert("type".to_string(), type_::type_);
@@ -81,36 +92,42 @@ impl ShellCore {
         self.builtins.insert("true".to_string(), true_);
         self.builtins.insert("wait".to_string(), job_commands::wait);
 
-        self.substitution_builtins.insert("export".to_string(), parameter::export);
-        self.substitution_builtins.insert("readonly".to_string(), parameter::readonly);
-        self.substitution_builtins.insert("typeset".to_string(), parameter::declare);
-        self.substitution_builtins.insert("declare".to_string(), parameter::declare);
-        self.substitution_builtins.insert("local".to_string(), parameter::local);
+        self.substitution_builtins
+            .insert("export".to_string(), parameter::export);
+        self.substitution_builtins
+            .insert("readonly".to_string(), parameter::readonly);
+        self.substitution_builtins
+            .insert("typeset".to_string(), parameter::declare);
+        self.substitution_builtins
+            .insert("declare".to_string(), parameter::declare);
+        self.substitution_builtins
+            .insert("local".to_string(), parameter::local);
     }
 }
 
-pub fn eval(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn eval(core: &mut ShellCore, args: &[String]) -> i32 {
+    let mut args = args.to_vec();
     args.remove(0);
-    if args.len() > 0 && args[0] == "--" {
+    if !args.is_empty() && args[0] == "--" {
         args.remove(0);
     }
 
     let mut feeder = Feeder::new(&args.join(" "));
 
     core.eval_level += 1;
-    match Script::parse(&mut feeder, core, false){
+    match Script::parse(&mut feeder, core, false) {
         Ok(Some(mut s)) => {
             let _ = s.exec(core);
-        },
+        }
         Err(e) => e.print(core),
-        _        => {},
+        _ => {}
     }
 
     core.eval_level -= 1;
     core.db.exit_status
 }
 
-pub fn exit(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn exit(core: &mut ShellCore, args: &[String]) -> i32 {
     if core.db.flags.contains('i') {
         eprintln!("exit");
     }
@@ -123,39 +140,37 @@ pub fn exit(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     exit::normal(core)
 }
 
-pub fn false_(_: &mut ShellCore, _: &mut Vec<String>) -> i32 {
+pub fn false_(_: &mut ShellCore, _: &[String]) -> i32 {
     1
 }
 
-pub fn true_(_: &mut ShellCore, _: &mut Vec<String>) -> i32 {
+pub fn true_(_: &mut ShellCore, _: &[String]) -> i32 {
     0
 }
 
-pub fn bind(_: &mut ShellCore, _: &mut Vec<String>) -> i32 {
+pub fn bind(_: &mut ShellCore, _: &[String]) -> i32 {
     0
 }
 
-pub fn debug(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn debug(core: &mut ShellCore, args: &[String]) -> i32 {
     dbg!("{:?}", &args);
     dbg!("{:?}", &core.db.get_param("depth"));
     0
 }
 
-pub fn let_(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn let_(core: &mut ShellCore, args: &[String]) -> i32 {
     let mut last_result = 0;
     for a in &args[1..] {
         match ArithmeticExpr::parse(&mut Feeder::new(&a.replace("$", "\\$")), core, false, "") {
-            Ok(Some(mut a)) => {
-                match a.eval(core) {
-                    Ok(s) => last_result = if s == "0" {1} else {0},
-                    Err(e) => {
-                        return error_exit(1, &args[0], &String::from(&e), core);
-                    },
+            Ok(Some(mut a)) => match a.eval(core) {
+                Ok(s) => last_result = if s == "0" { 1 } else { 0 },
+                Err(e) => {
+                    return error_exit(1, &args[0], &String::from(&e), core);
                 }
             },
             Ok(None) => {
                 return error_exit(1, &args[0], "expression expected", core);
-            },
+            }
             Err(e) => {
                 return error_exit(1, &args[0], &String::from(&e), core);
             }

--- a/src/core/builtins/alias.rs
+++ b/src/core/builtins/alias.rs
@@ -3,15 +3,15 @@
 
 use crate::ShellCore;
 
-pub fn alias(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn alias(core: &mut ShellCore, args: &[String]) -> i32 {
     if args.len() == 1 {
         for (k, v) in &core.aliases {
-            println!("alias {}='{}'", k, v);
+            println!("alias {k}='{v}'");
         }
         return 0;
     }
 
-    if args.len() == 2 && args[1].find("=") != None {
+    if args.len() == 2 && args[1].contains("=") {
         let kv: Vec<String> = args[1].split("=").map(|t| t.to_string()).collect();
         core.aliases.insert(kv[0].clone(), kv[1..].join("="));
     }
@@ -19,7 +19,7 @@ pub fn alias(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     0
 }
 
-pub fn unalias(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn unalias(core: &mut ShellCore, args: &[String]) -> i32 {
     if args.len() <= 1 {
         println!("unalias: usage: unalias [-a] name [name ...]");
     }
@@ -29,9 +29,9 @@ pub fn unalias(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
         return 0;
     }
 
-    args[1..].iter()
-        .for_each(|e| {core.aliases.remove_entry(e);} );
+    args[1..].iter().for_each(|e| {
+        core.aliases.remove_entry(e);
+    });
 
     0
 }
-

--- a/src/core/builtins/cd.rs
+++ b/src/core/builtins/cd.rs
@@ -2,69 +2,79 @@
 //SPDX-FileCopyrightText: 2023 @caro@mi.shellgei.org
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{error, ShellCore};
 use crate::arg;
 use crate::utils::file;
+use crate::{error, ShellCore};
 
-pub fn cd(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn cd(core: &mut ShellCore, args: &[String]) -> i32 {
     if core.db.flags.contains('r') {
         return super::error_exit(1, &args[0], "restricted", core);
     }
 
-    let _ = arg::consume_option("--", args);
+    let mut filtered = args.to_vec();
+    let _ = arg::consume_option("--", &mut filtered);
 
-    if args.len() > 2 {
+    if filtered.len() > 2 {
         eprintln!("sush: cd: too many arguments");
         return 1;
     }
 
-    if args.len() == 1 { //only "cd"
-        return cd_1arg(core, args);
+    if filtered.len() == 1 {
+        //only "cd"
+        return cd_1arg(core, &filtered);
     }
 
-    if args[1] == "-" { // cd -
-        cd_oldpwd(core, args)
-    }else{ // cd /some/dir
+    if filtered[1] == "-" {
+        // cd -
+        cd_oldpwd(core, &filtered)
+    } else {
+        // cd /some/dir
         set_oldpwd(core);
-        change_directory(core, args)
+        change_directory(core, &filtered)
     }
 }
 
-fn cd_1arg(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    let var = "~".to_string();
-    args.push(var);
+fn cd_1arg(core: &mut ShellCore, args: &[String]) -> i32 {
+    let mut extended = args.to_vec();
+    extended.push("~".to_string());
     set_oldpwd(core);
-    change_directory(core, args)
+    change_directory(core, &extended)
 }
 
-fn cd_oldpwd(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    match core.db.get_param("OLDPWD") {
+fn cd_oldpwd(core: &mut ShellCore, args: &[String]) -> i32 {
+    let old = match core.db.get_param("OLDPWD") {
         Ok(old) => {
             println!("{}", &old);
-            args[1] = old.to_string();
-        },
+            old.to_string()
+        }
         Err(_) => {
             error::print("cd: OLDPWD not set", core);
             return 1;
-        },
-    }
+        }
+    };
 
+    let mut modified = args.to_vec();
+    modified[1] = old;
     set_oldpwd(core);
-    change_directory(core, args)
+    change_directory(core, &modified)
 }
 
 fn set_oldpwd(core: &mut ShellCore) {
     if let Some(old) = core.get_current_directory() {
-        let _ = core.db.set_param("OLDPWD", &old.display().to_string(), Some(0));
+        let _ = core
+            .db
+            .set_param("OLDPWD", &old.display().to_string(), Some(0));
     };
 }
 
-fn change_directory(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+fn change_directory(core: &mut ShellCore, args: &[String]) -> i32 {
     let path = file::make_canonical_path(core, &args[1]);
     if core.set_current_directory(&path).is_ok() {
-        let _ = core.db.set_param("PWD", &path.display().to_string(), Some(0));
+        let _ = core
+            .db
+            .set_param("PWD", &path.display().to_string(), Some(0));
         0
-    }else{
+    } else {
         eprintln!("sush: cd: {:?}: No such file or directory", &path);
         1
     }

--- a/src/core/builtins/command.rs
+++ b/src/core/builtins/command.rs
@@ -1,25 +1,25 @@
 //SPDX-FileCopyrightText: 2025 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{error, proc_ctrl, ShellCore};
 use crate::elements::command::simple::SimpleCommand;
 use crate::elements::io::pipe::Pipe;
 use crate::utils::{arg, file};
+use crate::{error, proc_ctrl, ShellCore};
 
-pub fn builtin(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn builtin(core: &mut ShellCore, args: &[String]) -> i32 {
     if args.len() <= 1 {
         return 0;
     }
 
-    if ! core.builtins.contains_key(&args[1]) {
+    if !core.builtins.contains_key(&args[1]) {
         let msg = format!("{}: not a shell builtin", &args[1]);
         return super::error_exit(1, &args[0], &msg, core);
     }
 
-    core.builtins[&args[1]](core, &mut args[1..].to_vec())
+    core.builtins[&args[1]](core, &args[1..])
 }
 
-fn command_v(words: &mut Vec<String>, core: &mut ShellCore, large_v: bool) -> i32 {
+fn command_v(words: &[String], core: &mut ShellCore, large_v: bool) -> i32 {
     if words.is_empty() {
         return 0;
     }
@@ -29,24 +29,24 @@ fn command_v(words: &mut Vec<String>, core: &mut ShellCore, large_v: bool) -> i3
     for com in words.iter() {
         if core.aliases.contains_key(com) {
             match large_v {
-                true  => println!("{} is aliased to `{}'", &com, core.aliases[com]),
+                true => println!("{} is aliased to `{}'", &com, core.aliases[com]),
                 false => println!("alias {}='{}'", &com, &core.aliases[com]),
             }
-        }else if core.builtins.contains_key(com) {
+        } else if core.builtins.contains_key(com) {
             return_value = 0;
 
             match large_v {
-                true  => println!("{} is a shell builtin", &com),
+                true => println!("{} is a shell builtin", &com),
                 false => println!("{}", &com),
             }
-        }else if let Some(path) = file::search_command(&com) {
+        } else if let Some(path) = file::search_command(com) {
             return_value = 0;
             match large_v {
-                true  => println!("{} is {}", &com, &path),
+                true => println!("{} is {}", &com, &path),
                 false => println!("{}", &com),
             }
-        }else if large_v {
-            let msg = format!("command: {}: not found", com);
+        } else if large_v {
+            let msg = format!("command: {com}: not found");
             error::print(&msg, core);
         }
     }
@@ -54,12 +54,10 @@ fn command_v(words: &mut Vec<String>, core: &mut ShellCore, large_v: bool) -> i3
     return_value
 }
 
-pub fn command(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    let mut args = arg::dissolve_options(args);
-    if core.db.flags.contains('r') {
-        if arg::consume_option("-p", &mut args) {
-            return super::error_exit(1, &args[0], "-p: restricted", core);
-        }
+pub fn command(core: &mut ShellCore, args: &[String]) -> i32 {
+    let mut args = arg::dissolve_options(&args.to_vec());
+    if core.db.flags.contains('r') && arg::consume_option("-p", &mut args) {
+        return super::error_exit(1, &args[0], "-p: restricted", core);
     }
 
     if args.len() <= 1 {
@@ -69,12 +67,12 @@ pub fn command(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     let mut pos = 1;
     while args.len() > pos {
         match args[pos].starts_with("-") {
-            true  => pos += 1,
+            true => pos += 1,
             false => break,
         }
     }
 
-    let mut words = args[pos..].to_vec();
+    let words = args[pos..].to_vec();
     if words.is_empty() {
         return 0;
     }
@@ -84,9 +82,9 @@ pub fn command(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
 
     let last_option = args.last().unwrap();
     if last_option == "-V" || last_option == "-v" {
-        return command_v(&mut words, core, last_option == "-V");
-    }else if core.builtins.contains_key(&words[0]) {
-        return core.builtins[&words[0]](core, &mut words);
+        return command_v(&words, core, last_option == "-V");
+    } else if core.builtins.contains_key(&words[0]) {
+        return core.builtins[&words[0]](core, &words);
     }
 
     let mut command = SimpleCommand::default();

--- a/src/core/builtins/exec.rs
+++ b/src/core/builtins/exec.rs
@@ -2,11 +2,11 @@
 //SPDX-License-Identifier: BSD-3-Clause
 
 use crate::{proc_ctrl, ShellCore};
-use nix::unistd;
 use nix::errno::Errno;
+use nix::unistd;
 use std::ffi::CString;
 
-pub fn exec(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn exec(core: &mut ShellCore, args: &[String]) -> i32 {
     if core.db.flags.contains('r') {
         return super::error_exit(1, &args[0], "restricted", core);
     }
@@ -16,33 +16,34 @@ pub fn exec(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     }
 
     if core.db.flags.contains('i') || core.shopts.query("execfail") {
-        exec_command(&args[1..].to_vec(), core, &"".to_string())
-    }else{
-        proc_ctrl::exec_command(&args[1..].to_vec(), core, &"".to_string())
+        exec_command(&args[1..], core, "")
+    } else {
+        proc_ctrl::exec_command(&args[1..], core, "")
     }
 }
 
-fn exec_command(args: &Vec<String>, core: &mut ShellCore, fullpath: &String) -> i32 {
-    let cargs: Vec<CString> = args.iter().map(|a| CString::new(a.to_string()).unwrap()).collect();
+fn exec_command(args: &[String], core: &mut ShellCore, fullpath: &str) -> i32 {
+    let cargs: Vec<CString> = args
+        .iter()
+        .map(|a| CString::new(a.to_string()).unwrap())
+        .collect();
     let cfullpath = CString::new(fullpath.to_string()).unwrap();
 
-    if ! fullpath.is_empty() {
+    if !fullpath.is_empty() {
         let _ = unistd::execv(&cfullpath, &cargs);
-    
     }
     let result = unistd::execvp(&cargs[0], &cargs);
 
     match result {
-        Err(Errno::E2BIG) => 
-            return super::error_exit(126, &args[0], "Arg list too long", core),
-        Err(Errno::EACCES) => 
-            return super::error_exit(126, &args[0], "cannot execute: Permission denied", core),
-        Err(Errno::ENOENT) =>
-            return super::error_exit(127, &args[0], "No such file or directory", core),
+        Err(Errno::E2BIG) => super::error_exit(126, &args[0], "Arg list too long", core),
+        Err(Errno::EACCES) => {
+            super::error_exit(126, &args[0], "cannot execute: Permission denied", core)
+        }
+        Err(Errno::ENOENT) => super::error_exit(127, &args[0], "No such file or directory", core),
         Err(e) => {
             let msg = format!("{:?}", &e);
-            return super::error_exit(127, &args[0], &msg, core);
-        },
-        _ => return 127,
+            super::error_exit(127, &args[0], &msg, core)
+        }
+        _ => 127,
     }
 }

--- a/src/core/builtins/getopts.rs
+++ b/src/core/builtins/getopts.rs
@@ -12,14 +12,14 @@ enum Opt {
 impl Opt {
     fn is_single(&self, opt: &str) -> bool {
         match self {
-            Self::Single(s) => return s == opt,
+            Self::Single(s) => s == opt,
             _ => false,
         }
     }
 
     fn is_witharg(&self, opt: &str) -> bool {
         match self {
-            Self::WithArg(s) => return s == opt,
+            Self::WithArg(s) => s == opt,
             _ => false,
         }
     }
@@ -34,23 +34,24 @@ fn parse(optstring: &str) -> (Vec<Opt>, bool) {
         optstring.remove(0);
         silence = true;
     }
-    
+
     for c in optstring.chars() {
         if c == ':' {
             match ans.pop() {
-                Some(Opt::Single(opt)) => ans.push( Opt::WithArg(opt) ),
+                Some(Opt::Single(opt)) => ans.push(Opt::WithArg(opt)),
                 _ => return (vec![], silence),
             }
-        }else{
-            let opt = format!("-{}", c);
-            ans.push( Opt::Single(opt) );
+        } else {
+            let opt = format!("-{c}");
+            ans.push(Opt::Single(opt));
         }
     }
 
     (ans, silence)
 }
 
-pub fn get_index(core: &mut ShellCore) -> (usize, usize) { //index, subindex
+pub fn get_index(core: &mut ShellCore) -> (usize, usize) {
+    //index, subindex
     let mut index = 1;
     let mut subindex = 0;
 
@@ -77,44 +78,67 @@ pub fn get_index(core: &mut ShellCore) -> (usize, usize) { //index, subindex
     (index, subindex)
 }
 
-fn set_no_arg_option(name: &str, arg: &str, index: usize, subindex: usize,
-                     subarg: bool, exp_args_len: usize, silence: bool,
-                     core: &mut ShellCore, layer: Option<usize>) -> i32 {
-    let result = core.db.set_param(&name, &arg[1..], layer);
+fn set_no_arg_option(
+    name: &str,
+    arg: &str,
+    index: usize,
+    subindex: usize,
+    subarg: bool,
+    exp_args_len: usize,
+    silence: bool,
+    core: &mut ShellCore,
+    layer: Option<usize>,
+) -> i32 {
+    let result = core.db.set_param(name, &arg[1..], layer);
     let _ = core.db.set_param("OPTARG", "", layer);
 
-    if ! subarg || subindex + 1 == exp_args_len {
-        let _ = core.db.set_param("OPTIND", &(index+1).to_string(), layer);
+    if !subarg || subindex + 1 == exp_args_len {
+        let _ = core.db.set_param("OPTIND", &(index + 1).to_string(), layer);
         let _ = core.db.set_param("OPTIND_SUB", "0", layer);
-        let _ = core.db.set_param("OPTIND_PREV", &(index+1).to_string(), layer);
-    }else{
+        let _ = core
+            .db
+            .set_param("OPTIND_PREV", &(index + 1).to_string(), layer);
+    } else {
         let _ = core.db.set_param("OPTIND", &index.to_string(), layer);
-        let _ = core.db.set_param("OPTIND_SUB", &(subindex + 1).to_string(), layer);
+        let _ = core
+            .db
+            .set_param("OPTIND_SUB", &(subindex + 1).to_string(), layer);
         let _ = core.db.set_param("OPTIND_PREV", &index.to_string(), layer);
     }
 
     if let Err(e) = result {
-        if ! silence {
+        if !silence {
             let msg = format!("getopts: {:?}", &e);
             error::print(&msg, core);
         }
         return 1;
     }
-    return 0;
+    0
 }
 
-fn set_option_with_arg(name: &str, arg: &str, index: usize, optarg: &str,
-                     silence: bool ,core: &mut ShellCore, layer: Option<usize>) -> i32 {
-    let result = core.db.set_param(&name, &arg[1..], layer);
+fn set_option_with_arg(
+    name: &str,
+    arg: &str,
+    index: usize,
+    optarg: &str,
+    silence: bool,
+    core: &mut ShellCore,
+    layer: Option<usize>,
+) -> i32 {
+    let result = core.db.set_param(name, &arg[1..], layer);
 
-    let _ = core.db.set_param("OPTARG", &optarg, layer);
-    let _ = core.db.set_param("OPTIND", &(index+2).to_string(), layer);
-    let _ = core.db.set_param("OPTIND_PREV", &(index+2).to_string(), layer);
+    let _ = core.db.set_param("OPTARG", optarg, layer);
+    let _ = core.db.set_param("OPTIND", &(index + 2).to_string(), layer);
+    let _ = core
+        .db
+        .set_param("OPTIND_PREV", &(index + 2).to_string(), layer);
     let _ = core.db.set_param("OPTIND_SUB", "0", layer);
 
     if let Err(e) = result {
-        let _ = core.db.set_param("OPTIND_PREV", &(index+10).to_string(), layer);
-        if ! silence {
+        let _ = core
+            .db
+            .set_param("OPTIND_PREV", &(index + 10).to_string(), layer);
+        if !silence {
             let msg = format!("getopts: {:?}", &e);
             error::print(&msg, core);
         }
@@ -124,7 +148,7 @@ fn set_option_with_arg(name: &str, arg: &str, index: usize, optarg: &str,
     0
 }
 
-pub fn getopts(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn getopts(core: &mut ShellCore, args: &[String]) -> i32 {
     let layer = core.db.get_layer_pos("OPTIND").unwrap_or(0);
     let layer_sub = core.db.get_layer_pos("OPTIND_SUB").unwrap_or(0);
     let layer_prev = core.db.get_layer_pos("OPTIND_PREV").unwrap_or(0);
@@ -153,7 +177,7 @@ pub fn getopts(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     let _ = core.db.set_param(&name, "?", Some(layer));
 
     let args = match args.len() > 3 {
-        true  => &args[2..],
+        true => &args[2..],
         false => &core.db.position_parameters.last().unwrap().clone(),
     };
 
@@ -171,23 +195,37 @@ pub fn getopts(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
         arg = exp_args[subindex].clone();
     }
 
-    if ! arg.starts_with("-") {
+    if !arg.starts_with("-") {
         return 1;
     }
 
     if arg.starts_with("--") {
-        let _ = core.db.set_param("OPTIND", &(index+1).to_string(), Some(layer));
-        let _ = core.db.set_param("OPTIND_PREV", &(index+1).to_string(), Some(layer));
+        let _ = core
+            .db
+            .set_param("OPTIND", &(index + 1).to_string(), Some(layer));
+        let _ = core
+            .db
+            .set_param("OPTIND_PREV", &(index + 1).to_string(), Some(layer));
         return 1;
     }
 
-    if targets.iter().any(|t| t.is_single(&arg) ) {
-        return set_no_arg_option(&name, &arg, index, subindex, subarg, exp_args.len(), silence, core, Some(layer));
+    if targets.iter().any(|t| t.is_single(&arg)) {
+        return set_no_arg_option(
+            &name,
+            &arg,
+            index,
+            subindex,
+            subarg,
+            exp_args.len(),
+            silence,
+            core,
+            Some(layer),
+        );
     }
 
-    if targets.iter().any(|t| t.is_witharg(&arg) ) {
-        let optarg = match args.len() > index+1 {
-            true  => args[index+1].clone(),
+    if targets.iter().any(|t| t.is_witharg(&arg)) {
+        let optarg = match args.len() > index + 1 {
+            true => args[index + 1].clone(),
             false => return 1,
         };
 

--- a/src/core/builtins/hash.rs
+++ b/src/core/builtins/hash.rs
@@ -1,8 +1,8 @@
 //SPDX-FileCopyrightText: 2025 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
 use crate::utils::arg;
+use crate::ShellCore;
 
 fn print_all(core: &mut ShellCore) -> i32 {
     println!("hits	command");
@@ -18,8 +18,8 @@ fn print_all(core: &mut ShellCore) -> i32 {
     0
 }
 
-pub fn hash(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    let mut args = arg::dissolve_options(args);
+pub fn hash(core: &mut ShellCore, args: &[String]) -> i32 {
+    let mut args = arg::dissolve_options(&args.to_vec());
 
     if args.len() == 1 {
         return print_all(core);
@@ -33,7 +33,10 @@ pub fn hash(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
             return super::error_exit(1, "hash", "still not implemented", core);
         }
 
-        if let Err(e) = core.db.set_assoc_elem("BASH_CMDS", &args[2], &args[1], None) {
+        if let Err(e) = core
+            .db
+            .set_assoc_elem("BASH_CMDS", &args[2], &args[1], None)
+        {
             let msg = String::from(&e);
             return super::error_exit(1, "hash", &msg, core);
         }

--- a/src/core/builtins/history.rs
+++ b/src/core/builtins/history.rs
@@ -1,8 +1,8 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
 use crate::utils::arg;
+use crate::ShellCore;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
@@ -12,8 +12,8 @@ pub fn history_c(core: &mut ShellCore) -> i32 {
     0
 }
 
-pub fn history(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    let mut args = arg::dissolve_options(args);
+pub fn history(core: &mut ShellCore, args: &[String]) -> i32 {
+    let mut args = arg::dissolve_options(&args.to_vec());
     if arg::consume_option("-c", &mut args) {
         return history_c(core);
     }
@@ -25,14 +25,14 @@ pub fn history(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
 
     let mut number = 1;
 
-    let filename = core.db.get_param("HISTFILE").unwrap_or(String::new());
-    if filename == "" {
+    let filename = core.db.get_param("HISTFILE").unwrap_or_default();
+    if filename.is_empty() {
         return 0;
     }
 
     let file = match File::open(&filename) {
         Ok(f) => f,
-        _     => return 0,
+        _ => return 0,
     };
 
     let f = BufReader::new(file);

--- a/src/core/builtins/job_commands.rs
+++ b/src/core/builtins/job_commands.rs
@@ -1,26 +1,21 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
-use crate::{signal, utils};
 use crate::core::JobEntry;
 use crate::utils::arg;
+use crate::ShellCore;
+use crate::{signal, utils};
 use nix::sys::signal::Signal;
 use nix::unistd;
 use nix::unistd::Pid;
 use std::{thread, time};
 
-fn pid_to_array_pos(pid: i32, jobs: &Vec<JobEntry>) -> Option<usize> {
-    for i in 0..jobs.len() {
-        if jobs[i].pids[0].as_raw() == pid {
-            return Some(i);
-        }
-    }
-    None
+fn pid_to_array_pos(pid: i32, jobs: &[JobEntry]) -> Option<usize> {
+    (0..jobs.len()).find(|&i| jobs[i].pids[0].as_raw() == pid)
 }
 
-fn jobid_to_pos(id: usize, jobs: &mut Vec<JobEntry>) -> Option<usize> {
-    for (i, job) in jobs.iter_mut().enumerate() {
+fn jobid_to_pos(id: usize, jobs: &[JobEntry]) -> Option<usize> {
+    for (i, job) in jobs.iter().enumerate() {
         if job.id == id {
             return Some(i);
         }
@@ -28,13 +23,13 @@ fn jobid_to_pos(id: usize, jobs: &mut Vec<JobEntry>) -> Option<usize> {
     None
 }
 
-pub fn bg(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn bg(core: &mut ShellCore, args: &[String]) -> i32 {
     if core.job_table.is_empty() {
         return 1;
     }
 
-    let mut args = arg::dissolve_options(args);
-    if ! core.db.flags.contains('m') {
+    let mut args = arg::dissolve_options(&args.to_vec());
+    if !core.db.flags.contains('m') {
         return super::error_exit(1, &args[0], "no job control", core);
     }
 
@@ -45,15 +40,15 @@ pub fn bg(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     let pos = match args.len() {
         1 => {
             let id = core.job_table_priority[0];
-            jobid_to_pos(id, &mut core.job_table)
-        },
+            jobid_to_pos(id, &core.job_table)
+        }
         2 => jobspec_to_array_pos(core, &args[0], &args[1]),
         _ => None,
     };
 
     match pos {
         Some(p) => {
-            let id = core.job_table[p].id; 
+            let id = core.job_table[p].id;
 
             if core.job_table[p].no_control {
                 let msg = format!("job {} started without job control", &id);
@@ -73,15 +68,15 @@ pub fn bg(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
             };
             println!("[{}]{} {} &", &id, &symbol, &core.job_table[p].text);
             core.job_table[p].send_cont()
-        },
-        None    => return 1,
+        }
+        None => return 1,
     }
     0
 }
 
-pub fn fg(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    let mut args = arg::dissolve_options(args);
-    if ! core.db.flags.contains('m') {
+pub fn fg(core: &mut ShellCore, args: &[String]) -> i32 {
+    let mut args = arg::dissolve_options(&args.to_vec());
+    if !core.db.flags.contains('m') {
         return super::error_exit(1, &args[0], "no job control", core);
     }
 
@@ -94,22 +89,22 @@ pub fn fg(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
             return 1;
         }
         core.job_table_priority[0]
-    }else if args.len() == 2 {
+    } else if args.len() == 2 {
         match jobspec_to_array_pos(core, &args[0], &args[1]) {
             Some(pos) => core.job_table[pos].id,
             None => return 1,
         }
-    }else{
+    } else {
         return 1;
     };
 
-    let pos = match jobid_to_pos(id, &mut core.job_table) {
+    let pos = match jobid_to_pos(id, &core.job_table) {
         Some(i) => i,
-        _ => return 1, 
+        _ => return 1,
     };
 
     if core.job_table[pos].no_control {
-        let id = core.job_table[pos].id; 
+        let id = core.job_table[pos].id;
         let msg = format!("job {} started without job control", &id);
         return super::error_exit(1, &args[0], &msg, core);
     }
@@ -123,21 +118,21 @@ pub fn fg(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
 
     let mut exit_status = 1;
     if let Some(fd) = core.tty_fd.as_ref() {
-        if let Ok(_) = unistd::tcsetpgrp(fd, pgid) {
+        if unistd::tcsetpgrp(fd, pgid).is_ok() {
             println!("{}", &core.job_table[pos].text);
             core.job_table[pos].send_cont();
             exit_status = core.job_table[pos].update_status(true, false).unwrap_or(1);
-    
+
             if let Ok(mypgid) = unistd::getpgid(Some(Pid::from_raw(0))) {
                 let _ = unistd::tcsetpgrp(fd, mypgid);
             }
         }
-    }else{
+    } else {
         println!("{}", &core.job_table[pos].text);
         core.job_table[pos].send_cont();
         exit_status = core.job_table[pos].update_status(true, false).unwrap_or(1);
     }
-    
+
     remove(core, pos);
     signal::restore(Signal::SIGTTOU);
     exit_status
@@ -147,9 +142,9 @@ fn jobspec_to_array_pos(core: &mut ShellCore, com: &str, jobspec: &str) -> Optio
     let poss = jobspec_to_array_poss(core, jobspec);
     if poss.is_empty() {
         let msg = format!("{}: no such job", &jobspec);
-        super::error_exit(127, &com, &msg, core);
+        super::error_exit(127, com, &msg, core);
         return None;
-    }else if poss.len() > 1 {
+    } else if poss.len() > 1 {
         let msg = format!("{}: ambiguous job spec", &jobspec[1..]);
         super::error_exit(127, com, &msg, core);
         return None;
@@ -159,7 +154,7 @@ fn jobspec_to_array_pos(core: &mut ShellCore, com: &str, jobspec: &str) -> Optio
 }
 
 fn jobspec_to_array_poss(core: &mut ShellCore, jobspec: &str) -> Vec<usize> {
-    if jobspec == "" {
+    if jobspec.is_empty() {
         return (0..core.job_table.len()).collect();
     }
 
@@ -176,31 +171,29 @@ fn jobspec_to_array_poss(core: &mut ShellCore, jobspec: &str) -> Vec<usize> {
                 ans.push(i);
             }
         }
-    }else if s == "%" || s == "+" {
+    } else if s == "%" || s == "+" {
         for (i, job) in core.job_table.iter_mut().enumerate() {
             if job.id == core.job_table_priority[0] {
                 ans.push(i);
             }
         }
-    }else if s == "-" {
+    } else if s == "-" {
         for (i, job) in core.job_table.iter_mut().enumerate() {
             if core.job_table_priority.len() < 2 {
                 if job.id == core.job_table_priority[0] {
                     ans.push(i);
                 }
-            }else {
-                if job.id == core.job_table_priority[1] {
-                    ans.push(i);
-                }
-            }
-        }
-    }else if s.starts_with("?") {
-        for (i, job) in core.job_table.iter_mut().enumerate() {
-            if job.text.contains(&s[1..]) {
+            } else if job.id == core.job_table_priority[1] {
                 ans.push(i);
             }
         }
-    }else {
+    } else if let Some(stripped) = s.strip_prefix("?") {
+        for (i, job) in core.job_table.iter_mut().enumerate() {
+            if job.text.contains(stripped) {
+                ans.push(i);
+            }
+        }
+    } else {
         for (i, job) in core.job_table.iter_mut().enumerate() {
             if job.text.starts_with(s) {
                 ans.push(i);
@@ -211,8 +204,8 @@ fn jobspec_to_array_poss(core: &mut ShellCore, jobspec: &str) -> Vec<usize> {
     ans
 }
 
-pub fn jobs(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    let mut args = arg::dissolve_options(args);
+pub fn jobs(core: &mut ShellCore, args: &[String]) -> i32 {
+    let mut args = arg::dissolve_options(&args.to_vec());
     if arg::consume_option("-n", &mut args) {
         core.jobtable_print_status_change();
         return 0;
@@ -224,7 +217,7 @@ pub fn jobs(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
         None => String::new(),
     };
 
-    if core.job_table.is_empty() && jobspec == "" {
+    if core.job_table.is_empty() && jobspec.is_empty() {
         return 0;
     }
 
@@ -234,7 +227,7 @@ pub fn jobs(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
         let msg = format!("{}: no such job", &jobspec);
         return super::error_exit(127, "jobs", &msg, core);
     }
-    if poss.len() > 1 && ! jobspec.is_empty() {
+    if poss.len() > 1 && !jobspec.is_empty() {
         let msg = format!("{}: ambiguous job spec", &jobspec[1..]);
         super::error_exit(127, "jobs", &msg, core);
         let msg = format!("{}: no such job", &jobspec);
@@ -248,12 +241,11 @@ pub fn jobs(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
         return 0;
     }
 
-    if ! jobspec.is_empty() {
+    if !jobspec.is_empty() {
         let l_opt = arg::consume_option("-l", &mut args);
         let r_opt = arg::consume_option("-r", &mut args);
         let s_opt = arg::consume_option("-s", &mut args);
-        if core.job_table[poss[0]].print(&core.job_table_priority,
-                                l_opt, r_opt, s_opt, true) {
+        if core.job_table[poss[0]].print(&core.job_table_priority, l_opt, r_opt, s_opt, true) {
             remove(core, poss[0]);
         }
         return 0;
@@ -281,8 +273,7 @@ fn print(core: &mut ShellCore, args: &mut Vec<String>) {
 
     let mut rem = vec![];
     for id in 0..core.job_table.len() {
-        if core.job_table[id].print(&core.job_table_priority,
-                                l_opt, r_opt, s_opt, true) {
+        if core.job_table[id].print(&core.job_table_priority, l_opt, r_opt, s_opt, true) {
             rem.push(id);
         }
     }
@@ -291,23 +282,32 @@ fn print(core: &mut ShellCore, args: &mut Vec<String>) {
         remove(core, pos);
     }
 }
-                
+
 fn remove(core: &mut ShellCore, pos: usize) {
     let job_id = core.job_table[pos].id;
     core.job_table.remove(pos);
     core.job_table_priority.retain(|id| *id != job_id);
 }
 
-fn wait_jobspec(core: &mut ShellCore, com: &str, jobspec: &str,
-                var_name: &Option<String>, f_opt: bool) -> (i32, bool) {
+fn wait_jobspec(
+    core: &mut ShellCore,
+    com: &str,
+    jobspec: &str,
+    var_name: &Option<String>,
+    f_opt: bool,
+) -> (i32, bool) {
     match jobspec_to_array_pos(core, com, jobspec) {
         Some(pos) => wait_a_job(core, pos, var_name, f_opt),
-        None => return (127, false),
+        None => (127, false),
     }
 }
 
-fn wait_next(core: &mut ShellCore, ids: &Vec<usize>,
-             var_name: &Option<String>, f_opt: bool) -> (i32, bool) {
+fn wait_next(
+    core: &mut ShellCore,
+    ids: &[usize],
+    var_name: &Option<String>,
+    f_opt: bool,
+) -> (i32, bool) {
     if core.job_table_priority.is_empty() {
         return (127, false);
     }
@@ -321,14 +321,15 @@ fn wait_next(core: &mut ShellCore, ids: &Vec<usize>,
     loop {
         thread::sleep(time::Duration::from_millis(10)); //0.1秒周期に変更
         for (i, job) in core.job_table.iter_mut().enumerate() {
-            if ! ids.contains(&i) && ! ids.is_empty() {
+            if !ids.contains(&i) && !ids.is_empty() {
                 continue;
             }
 
             if let Ok(es) = job.update_status(false, true) {
                 if job.display_status == "Done"
-                || job.display_status == "Killed"
-                || (job.display_status == "Stopped" && ! f_opt) {
+                    || job.display_status == "Killed"
+                    || (job.display_status == "Stopped" && !f_opt)
+                {
                     exit_status = es;
                     drop = i;
                     end = true;
@@ -345,30 +346,36 @@ fn wait_next(core: &mut ShellCore, ids: &Vec<usize>,
     }
 
     if let Some(var) = var_name {
-        core.db.unset(&var);
-        if let Err(e) = core.db.set_param(&var, &pid, None) {
+        core.db.unset(var);
+        if let Err(e) = core.db.set_param(var, &pid, None) {
             e.print(core);
         }
     }
 
-    if remove_job { 
+    if remove_job {
         remove(core, drop);
     }
     (exit_status, true)
 }
 
-fn wait_pid(core: &mut ShellCore, pid: i32,
-            var_name: &Option<String>, f_opt: bool) -> (i32, bool) {
+fn wait_pid(core: &mut ShellCore, pid: i32, var_name: &Option<String>, f_opt: bool) -> (i32, bool) {
     match pid_to_array_pos(pid, &core.job_table) {
         Some(i) => wait_a_job(core, i, var_name, f_opt),
         None => (127, false),
     }
 }
 
-fn wait_a_job(core: &mut ShellCore, pos: usize,
-              var_name: &Option<String>, f_opt: bool) -> (i32, bool) {
+fn wait_a_job(
+    core: &mut ShellCore,
+    pos: usize,
+    var_name: &Option<String>,
+    f_opt: bool,
+) -> (i32, bool) {
     if core.job_table.len() < pos {
-        return (super::error_exit(127, "wait", "invalpos jobpos", core), false);
+        return (
+            super::error_exit(127, "wait", "invalpos jobpos", core),
+            false,
+        );
     }
 
     let pid = core.job_table[pos].pids[0].to_string();
@@ -376,35 +383,43 @@ fn wait_a_job(core: &mut ShellCore, pos: usize,
     let ans = match core.job_table[pos].update_status(true, false) {
         Ok(n) => {
             if let Some(var) = var_name {
-                core.db.unset(&var);
-                if let Err(e) = core.db.set_param(&var, &pid, None) {
+                core.db.unset(var);
+                if let Err(e) = core.db.set_param(var, &pid, None) {
                     e.print(core);
                 }
             }
             (n, true)
-        },
-        Err(e) => { e.print(core); return (1, false) },
+        }
+        Err(e) => {
+            e.print(core);
+            return (1, false);
+        }
     };
 
     if f_opt && core.job_table[pos].display_status == "Stopped" {
         wait_a_job(core, pos, var_name, f_opt)
-    }else{
+    } else {
         remove(core, pos);
         ans
     }
 }
 
-fn wait_arg_job(core: &mut ShellCore, com: &str, arg: &String,
-                var_name: &Option<String>, f_opt: bool) -> (i32, bool) {
+fn wait_arg_job(
+    core: &mut ShellCore,
+    com: &str,
+    arg: &str,
+    var_name: &Option<String>,
+    f_opt: bool,
+) -> (i32, bool) {
     if arg.starts_with("%") {
-        return wait_jobspec(core, com, &arg, &var_name, f_opt);
+        return wait_jobspec(core, com, arg, var_name, f_opt);
     }
 
     if let Ok(pid) = arg.parse::<i32>() {
-        return wait_pid(core, pid, &var_name, f_opt);
+        return wait_pid(core, pid, var_name, f_opt);
     }
 
-    (127, false) 
+    (127, false)
 }
 
 fn wait_all(core: &mut ShellCore) -> i32 {
@@ -414,16 +429,17 @@ fn wait_all(core: &mut ShellCore) -> i32 {
         match core.job_table[pos].update_status(true, false) {
             Ok(n) => {
                 if core.job_table[pos].display_status == "Done"
-                || core.job_table[pos].display_status == "Killed" {
+                    || core.job_table[pos].display_status == "Killed"
+                {
                     remove_list.push(pos);
                 }
                 exit_status = n;
-            },
+            }
             Err(e) => {
                 e.print(core);
                 exit_status = 1;
                 break;
-            },
+            }
         }
     }
 
@@ -431,22 +447,26 @@ fn wait_all(core: &mut ShellCore) -> i32 {
         remove(core, pos);
     }
 
-    return exit_status;
+    exit_status
 }
 
-fn wait_n(core: &mut ShellCore, args: &mut Vec<String>,
-          var_name: &Option<String>, f_opt: bool) -> i32 {
+fn wait_n(
+    core: &mut ShellCore,
+    args: &mut Vec<String>,
+    var_name: &Option<String>,
+    f_opt: bool,
+) -> i32 {
     let mut jobs = arg::consume_with_subsequents("-n", args);
     jobs.remove(0);
     if jobs.is_empty() {
-        return wait_next(core, &vec![], &var_name, f_opt).0;
+        return wait_next(core, &[], var_name, f_opt).0;
     }
 
     let mut ids = vec![];
     for j in &jobs {
         if j.starts_with("%") {
-            ids.append(&mut jobspec_to_array_poss(core, &j));
-        }else{
+            ids.append(&mut jobspec_to_array_poss(core, j));
+        } else {
             for (i, job) in core.job_table.iter_mut().enumerate() {
                 if job.pids[0].to_string() == *j {
                     ids.push(i);
@@ -460,18 +480,18 @@ fn wait_n(core: &mut ShellCore, args: &mut Vec<String>,
 
     for _ in 0..ids.len() {
         let tmp = match ans {
-            -1 => wait_next(core, &ids, &var_name, f_opt),
-            _  => wait_next(core, &ids, &None, f_opt),
+            -1 => wait_next(core, &ids, var_name, f_opt),
+            _ => wait_next(core, &ids, &None, f_opt),
         };
 
-        if tmp.1 == true && ans == -1 {
+        if tmp.1 && ans == -1 {
             ans = tmp.0;
         }
     }
-    return ans;
+    ans
 }
 
-pub fn wait(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn wait(core: &mut ShellCore, args: &[String]) -> i32 {
     if core.is_subshell {
         super::error_exit(127, &args[0], "called from subshell", core);
     }
@@ -480,7 +500,7 @@ pub fn wait(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
         return wait_all(core);
     }
 
-    let mut args = arg::dissolve_options(args);
+    let mut args = arg::dissolve_options(&args.to_vec());
     let var_name = arg::consume_with_next_arg("-p", &mut args);
     let f_opt = arg::consume_option("-f", &mut args);
 
@@ -495,12 +515,13 @@ pub fn wait(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
 }
 
 /* TODO: implement original kill */
-pub fn kill(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn kill(core: &mut ShellCore, args: &[String]) -> i32 {
     //let mut args = arg::dissolve_options(args);
+    let mut args = args.to_vec();
     let path = utils::get_command_path(&args[0], core);
 
     match path.is_empty() {
-        true  => return 1,
+        true => return 1,
         false => args[0] = path,
     }
 
@@ -517,9 +538,9 @@ pub fn kill(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
             *arg = "-s".to_string();
         }
         if arg.starts_with("%") {
-            if let Some(pos) = jobspec_to_array_pos(core, &com, &arg) {
+            if let Some(pos) = jobspec_to_array_pos(core, &com, arg) {
                 *arg = core.job_table[pos].pids[0].to_string();
-            }else{
+            } else {
                 let msg = format!("{}: no such job", &arg);
                 return super::error_exit(127, "jobs", &msg, core);
             }
@@ -527,11 +548,11 @@ pub fn kill(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     }
 
     args.insert(0, "eval".to_string());
-    super::eval(core, args)
+    super::eval(core, &args)
 }
 
-pub fn disown(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    let mut args = arg::dissolve_options(args);
+pub fn disown(core: &mut ShellCore, args: &[String]) -> i32 {
+    let mut args = arg::dissolve_options(&args.to_vec());
     let h_opt = arg::consume_option("-h", &mut args);
     let _r_opt = arg::consume_option("-r", &mut args); //TODO: implement
 
@@ -563,10 +584,10 @@ pub fn disown(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     }
 
     for a in &args[1..] {
-        if let Some(pos) = jobspec_to_array_pos(core, &args[0], &a) {
+        if let Some(pos) = jobspec_to_array_pos(core, &args[0], a) {
             if h_opt {
                 //TODO: to make each job doesn't stop by SIGHUP
-            }else{
+            } else {
                 remove(core, pos);
             }
         }

--- a/src/core/builtins/loop_control.rs
+++ b/src/core/builtins/loop_control.rs
@@ -3,7 +3,7 @@
 
 use crate::ShellCore;
 
-pub fn return_(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn return_(core: &mut ShellCore, args: &[String]) -> i32 {
     if core.source_function_level <= 0 {
         eprintln!("sush: return: can only `return' from a function or sourced script");
         return 2;
@@ -12,15 +12,15 @@ pub fn return_(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
 
     if args.len() < 2 {
         return 0;
-    }else if let Ok(n) = args[1].parse::<i32>() {
-        return n%256;
+    } else if let Ok(n) = args[1].parse::<i32>() {
+        return n % 256;
     }
 
     eprintln!("sush: return: {}: numeric argument required", args[1]);
     2
 }
 
-pub fn break_(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn break_(core: &mut ShellCore, args: &[String]) -> i32 {
     if core.loop_level <= 0 {
         eprintln!("sush: break: only meaningful in a `for', `while', or `until' loop");
         return 0;
@@ -32,23 +32,23 @@ pub fn break_(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     }
 
     match args[1].parse::<i32>() {
-        Ok(n)  => {
+        Ok(n) => {
             if n > 0 {
                 core.break_counter += n - 1;
-            }else{
+            } else {
                 eprintln!("sush: break: {}: loop count out of range", args[1]);
                 return 1;
             }
-        },
+        }
         Err(_) => {
             eprintln!("sush: break: {}: numeric argument required", args[1]);
             return 128;
-        },
+        }
     };
     0
 }
 
-pub fn continue_(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn continue_(core: &mut ShellCore, args: &[String]) -> i32 {
     if core.loop_level <= 0 {
         eprintln!("sush: continue: only meaningful in a `for', `while', or `until' loop");
         return 0;
@@ -60,18 +60,18 @@ pub fn continue_(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     }
 
     match args[1].parse::<i32>() {
-        Ok(n)  => {
+        Ok(n) => {
             if n > 0 {
                 core.continue_counter += n - 1;
-            }else{
+            } else {
                 eprintln!("sush: continue: {}: loop count out of range", args[1]);
                 return 1;
             }
-        },
+        }
         Err(_) => {
             eprintln!("sush: continue: {}: numeric argument required", args[1]);
             return 128;
-        },
+        }
     };
     0
 }

--- a/src/core/builtins/option.rs
+++ b/src/core/builtins/option.rs
@@ -1,9 +1,9 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{error, ShellCore};
 use crate::error::exec::ExecError;
 use crate::utils::arg;
+use crate::{error, ShellCore};
 
 pub fn set_positions(core: &mut ShellCore, args: &[String]) -> Result<(), ExecError> {
     if core.db.position_parameters.pop().is_none() {
@@ -16,7 +16,9 @@ pub fn set_positions(core: &mut ShellCore, args: &[String]) -> Result<(), ExecEr
 fn check_invalid_options(args: &mut Vec<String>) -> Result<(), ExecError> {
     for a in args {
         if a.starts_with("-") {
-            return Err(ExecError::InvalidOption("set: ".to_owned() + &a.to_string()));
+            return Err(ExecError::InvalidOption(
+                "set: ".to_owned() + &a.to_string(),
+            ));
         }
     }
     Ok(())
@@ -28,44 +30,52 @@ pub fn set_options(core: &mut ShellCore, args: &mut Vec<String>) -> Result<(), E
 }
 
 pub fn set_short_options(core: &mut ShellCore, args: &mut Vec<String>) {
-    for (short, long) in [('t', "onecmd"), ('m', "monitor"),
-                          ('C', "noclobber"), ('a', "allexport"),
-                          ('B', "braceexpand"), ('u', ""),
-                          ('e', ""), ('r', ""), ('H', "")] {
-        let minus_opt = format!("-{}", short);
-        let plus_opt = format!("+{}", short);
+    for (short, long) in [
+        ('t', "onecmd"),
+        ('m', "monitor"),
+        ('C', "noclobber"),
+        ('a', "allexport"),
+        ('B', "braceexpand"),
+        ('u', ""),
+        ('e', ""),
+        ('r', ""),
+        ('H', ""),
+    ] {
+        let minus_opt = format!("-{short}");
+        let plus_opt = format!("+{short}");
 
         if arg::consume_option(&minus_opt, args) {
-            if ! core.db.flags.contains(short) {
+            if !core.db.flags.contains(short) {
                 core.db.flags += &minus_opt[1..];
             }
-            if long != "" {
+            if !long.is_empty() {
                 let _ = core.options.set(long, true);
             }
         }
-    
+
         if arg::consume_option(&plus_opt, args) {
             core.db.flags.retain(|f| f != short);
-            if long != "" {
+            if !long.is_empty() {
                 let _ = core.options.set(long, false);
             }
         }
     }
 }
 
-pub fn set(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    let mut args = arg::dissolve_options(args);
+pub fn set(core: &mut ShellCore, args: &[String]) -> i32 {
+    let mut args = arg::dissolve_options(&args.to_vec());
 
-    if core.db.flags.contains('r') {
-        if arg::consume_option("+r", &mut args) {
-            let _ = super::error_exit(1, &args[0], "+r: invalid option", core);
-            eprintln!("set: usage: set [-abefhkmnptuvxBCEHPT] [-o option-name] [--] [-] [arg ...]"); // TODO: this line is a dummy for test. We must implement all behaviors of these options.
-            return 1;
-        }
+    if core.db.flags.contains('r') && arg::consume_option("+r", &mut args) {
+        let _ = super::error_exit(1, &args[0], "+r: invalid option", core);
+        eprintln!("set: usage: set [-abefhkmnptuvxBCEHPT] [-o option-name] [--] [-] [arg ...]"); // TODO: this line is a dummy for test. We must implement all behaviors of these options.
+        return 1;
     }
 
-    if args.len() <= 1 { /* print */
-        core.db.get_keys().into_iter()
+    if args.len() <= 1 {
+        /* print */
+        core.db
+            .get_keys()
+            .into_iter()
             .for_each(|k| core.db.print(&k));
         return 0;
     }
@@ -83,8 +93,8 @@ pub fn set(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
             Ok(()) => 0,
             Err(e) => {
                 return super::error_exit(1, &args[0], &String::from(&e), core);
-            },
-        }
+            }
+        };
     }
 
     if args[1] == "-o" || args[1] == "+o" {
@@ -93,25 +103,25 @@ pub fn set(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
         if args.len() == 2 {
             core.options.print_all(positive);
             return 0;
-        }else{
+        } else {
             if args[2] == "monitor" {
-                if positive && ! core.db.flags.contains('m') {
+                if positive && !core.db.flags.contains('m') {
                     core.db.flags.push('m');
-                }else if ! positive {
+                } else if !positive {
                     core.db.flags.retain(|f| f != 'm');
                 }
             }
 
             return match core.options.set(&args[2], positive) {
-                Ok(())  => 0,
+                Ok(()) => 0,
                 Err(e) => {
                     return super::error_exit(2, &args[0], &String::from(&e), core);
-                },
+                }
             };
         }
     }
 
-    if ! args[1].starts_with("-") && ! args[1].starts_with("+") {
+    if !args[1].starts_with("-") && !args[1].starts_with("+") {
         if let Err(e) = set_positions(core, &args) {
             e.print(core);
             return 2;
@@ -125,7 +135,7 @@ pub fn set(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     0
 }
 
-pub fn shift(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn shift(core: &mut ShellCore, args: &[String]) -> i32 {
     if args.len() == 1 {
         let mut last = core.db.position_parameters.pop().unwrap();
         if last.len() > 1 {
@@ -142,7 +152,7 @@ pub fn shift(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
                 let err = format!("shift: {}: numeric argument required", &args[1]);
                 error::print(&err, core);
                 return 1;
-            },
+            }
         };
 
         if n < 0 {
@@ -166,7 +176,7 @@ pub fn shift(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     1
 }
 
-pub fn shopt_print(core: &mut ShellCore, args: &mut Vec<String>, all: bool) -> i32 {
+pub fn shopt_print(core: &mut ShellCore, args: &[String], all: bool) -> i32 {
     if all {
         core.shopts.print_all(true);
         return 0;
@@ -177,35 +187,36 @@ pub fn shopt_print(core: &mut ShellCore, args: &mut Vec<String>, all: bool) -> i
         "-s" => core.shopts.print_if(true),
         "-u" => core.shopts.print_if(false),
         "-q" => return 0,
-        opt  => res = core.shopts.print_opt(opt, false),
+        opt => res = core.shopts.print_opt(opt, false),
     }
 
     match res {
-        true  => 0,
+        true => 0,
         false => 1,
     }
 }
 
-pub fn shopt(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    let mut args = arg::dissolve_options(args);
+pub fn shopt(core: &mut ShellCore, args: &[String]) -> i32 {
+    let mut args = arg::dissolve_options(&args.to_vec());
     let print = arg::consume_option("-p", &mut args);
     let o_opt = arg::consume_option("-o", &mut args);
     let q_opt = arg::consume_option("-q", &mut args);
 
     /* print section */
     if print && o_opt {
-        if args.len() >= 2 && ! q_opt {
+        if args.len() >= 2 && !q_opt {
             core.options.print_opt(&args[1], true);
-        }else if ! q_opt {
+        } else if !q_opt {
             core.options.print_all(false);
         }
         return 0;
     }
 
-    if args.len() < 3 { // "shopt" or "shopt option"
-        if ! q_opt {
+    if args.len() < 3 {
+        // "shopt" or "shopt option"
+        if !q_opt {
             let len = args.len();
-            return shopt_print(core, &mut args, len < 2);
+            return shopt_print(core, &args, len < 2);
         }
         return 0;
     }
@@ -216,53 +227,55 @@ pub fn shopt(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
             "-s" => "-o",
             "-u" => "+o",
             other => other,
-        }.to_string();
+        }
+        .to_string();
         let mut args_for_set = vec!["set".to_string(), opt];
         args_for_set.append(&mut args[2..].to_vec());
 
-        return set(core, &mut args_for_set);
+        return set(core, &args_for_set);
     }
 
-    match args[1].as_str() { //TODO: args[3..] must to be set
+    match args[1].as_str() {
+        //TODO: args[3..] must to be set
         "-s" => {
             if core.shopts.implemented.contains(&args[2]) {
                 match core.shopts.set(&args[2], true) {
-                    Ok(()) => return 0,
+                    Ok(()) => 0,
                     Err(e) => {
                         e.print(core);
-                        return 1;
-                    },
+                        1
+                    }
                 }
-            }else{
+            } else {
                 let msg = format!("shopt: {}: not supported yet", &args[2]);
                 error::print(&msg, core);
-                return 1;
+                1
             }
-        },
+        }
         "-q" => {
             for arg in &args[2..] {
-                if ! core.shopts.exist(arg) {
+                if !core.shopts.exist(arg) {
                     let msg = format!("shopt: {}: invalid shell option name", &arg);
                     error::print(&msg, core);
                     return 1;
                 }
-                if ! core.shopts.query(arg) {
+                if !core.shopts.query(arg) {
                     return 1;
                 }
             }
-            return 0;
-        },
+            0
+        }
         "-u" => match core.shopts.set(&args[2], false) {
-            Ok(()) => return 0,
+            Ok(()) => 0,
             Err(e) => {
                 e.print(core);
-                return 1;
-            },
+                1
+            }
         },
-        arg  => {
-            eprintln!("sush: shopt: {}: invalid shell option name", arg);
+        arg => {
+            eprintln!("sush: shopt: {arg}: invalid shell option name");
             eprintln!("shopt: usage: shopt [-su] [optname ...]");
-            return 1;
-        },
+            1
+        }
     }
 }

--- a/src/core/builtins/parameter.rs
+++ b/src/core/builtins/parameter.rs
@@ -1,24 +1,23 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{env, ShellCore, Feeder};
-use crate::error::exec::ExecError;
+use super::error_exit;
 use crate::elements::substitution::Substitution;
 use crate::elements::word::Word;
+use crate::error::exec::ExecError;
 use crate::utils::arg;
-use super::error_exit;
+use crate::{env, Feeder, ShellCore};
 
-pub fn local(core: &mut ShellCore,
-             args: &mut Vec<String>, subs: &mut Vec<Substitution>) -> i32 {
+pub fn local(core: &mut ShellCore, args: &[String], subs: &mut [Substitution]) -> i32 {
     let layer = if core.db.get_layer_num() > 2 {
-        core.db.get_layer_num() - 2//The last element of data.parameters is for local itself. 
-    }else{
+        core.db.get_layer_num() - 2 //The last element of data.parameters is for local itself.
+    } else {
         ExecError::ValidOnlyInFunction("local".to_string()).print(core);
         return 1;
     };
 
     for sub in subs.iter_mut() {
-        if let Err(e) = set_substitution(core, sub, &mut args.clone(), layer) {
+        if let Err(e) = set_substitution(core, sub, &mut args.to_vec(), layer) {
             e.print(core);
             return 1;
         }
@@ -30,7 +29,7 @@ pub fn local(core: &mut ShellCore,
 fn reparse(core: &mut ShellCore, sub: &mut Substitution) {
     let mut f = Feeder::new(&sub.text);
     let text = if let Ok(Some(s)) = Word::parse(&mut f, core, None) {
-        if ! f.is_empty() {
+        if !f.is_empty() {
             return;
         }
 
@@ -38,13 +37,13 @@ fn reparse(core: &mut ShellCore, sub: &mut Substitution) {
             Ok(txt) => txt,
             _ => return,
         }
-    }else{
+    } else {
         return;
     };
 
     let mut f = Feeder::new(&text.replace("~", "\\~"));
     if let Ok(Some(s)) = Substitution::parse(&mut f, core, false) {
-        if ! f.is_empty() {
+        if !f.is_empty() {
             return;
         }
 
@@ -52,8 +51,12 @@ fn reparse(core: &mut ShellCore, sub: &mut Substitution) {
     }
 }
 
-fn set_substitution(core: &mut ShellCore, sub: &mut Substitution, args: &mut Vec<String>,
-                    layer: usize) -> Result<(), ExecError> {
+fn set_substitution(
+    core: &mut ShellCore,
+    sub: &mut Substitution,
+    args: &mut Vec<String>,
+    layer: usize,
+) -> Result<(), ExecError> {
     if core.db.is_readonly(&sub.left_hand.name) {
         return Err(ExecError::VariableReadOnly(sub.left_hand.name.clone()));
     }
@@ -76,14 +79,15 @@ fn set_substitution(core: &mut ShellCore, sub: &mut Substitution, args: &mut Vec
     let mut res = Ok(());
 
     match sub.has_right {
-        true  => res = sub.eval(core, Some(layer), true),
+        true => res = sub.eval(core, Some(layer), true),
         false => {
-            if ! core.db.params[layer].contains_key(&sub.left_hand.name)
-            || ( ! core.db.is_array(&sub.left_hand.name) && args.contains(&"-a".to_string()) )
-            || ( ! core.db.is_assoc(&sub.left_hand.name) && args.contains(&"-A".to_string()) ) {
+            if !core.db.params[layer].contains_key(&sub.left_hand.name)
+                || (!core.db.is_array(&sub.left_hand.name) && args.contains(&"-a".to_string()))
+                || (!core.db.is_assoc(&sub.left_hand.name) && args.contains(&"-A".to_string()))
+            {
                 res = sub.left_hand.init_variable(core, Some(layer), args);
             }
-        },
+        }
     }
 
     if read_only {
@@ -95,18 +99,19 @@ fn set_substitution(core: &mut ShellCore, sub: &mut Substitution, args: &mut Vec
 
 fn declare_print(core: &mut ShellCore, names: &[String], com: &str) -> i32 {
     for n in names {
-        let mut opt = if core.db.is_assoc(&n) { "A" }
-        else if core.db.is_array(&n) { "a" }
-        else if core.db.has_value(&n) { "" }
-        else{
-            return error_exit(1, &n, "not found", core);
-        }.to_string();
+        let mut opt = if core.db.is_assoc(n) {
+            "A"
+        } else if core.db.is_array(n) {
+            "a"
+        } else if core.db.has_value(n) {
+            ""
+        } else {
+            return error_exit(1, n, "not found", core);
+        }
+        .to_string();
 
-        if core.db.is_readonly(&n) {
-            if ! opt.contains('r') 
-            && ! core.options.query("posix") {
-                opt += "r";
-            }
+        if core.db.is_readonly(n) && !opt.contains('r') && !core.options.query("posix") {
+            opt += "r";
         }
 
         if opt.is_empty() {
@@ -114,18 +119,20 @@ fn declare_print(core: &mut ShellCore, names: &[String], com: &str) -> i32 {
         }
 
         let prefix = match core.options.query("posix") {
-            false => format!("declare -{} ", opt),
-            true  => format!("{} -{} ", com, opt),
+            false => format!("declare -{opt} "),
+            true => format!("{com} -{opt} "),
         };
-        print!("{}", prefix);
-        core.db.print(&n);
+        print!("{prefix}");
+        core.db.print(n);
     }
     0
 }
 
 fn declare_print_all(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     if args.len() < 2 {
-        core.db.get_keys().into_iter()
+        core.db
+            .get_keys()
+            .into_iter()
             .for_each(|k| core.db.print(&k));
         return 0;
     }
@@ -135,7 +142,7 @@ fn declare_print_all(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
         names.sort();
 
         for n in names {
-            core.db.functions.get_mut(&n).unwrap().pretty_print(0); 
+            core.db.functions.get_mut(&n).unwrap().pretty_print(0);
         }
         return 0;
     }
@@ -160,17 +167,15 @@ fn declare_print_all(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
 
     if arg::consume_option("-r", args) {
         names.retain(|n| core.db.is_readonly(n));
-        if ! core.options.query("posix") {
+        if !core.options.query("posix") {
             options += "r";
         }
     }
 
-    let prefix = format!("declare -{}", options);
+    let prefix = format!("declare -{options}");
     for name in names {
-        print!("{}", prefix);
-        if core.db.is_readonly(&name)
-        && ! options.contains('r')
-        && ! core.options.query("posix") {
+        print!("{prefix}");
+        if core.db.is_readonly(&name) && !options.contains('r') && !core.options.query("posix") {
             print!("r");
         }
         print!(" ");
@@ -179,8 +184,8 @@ fn declare_print_all(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     0
 }
 
-pub fn declare(core: &mut ShellCore, args: &mut Vec<String>, subs: &mut Vec<Substitution>) -> i32 {
-    let mut args = arg::dissolve_options(args);
+pub fn declare(core: &mut ShellCore, args: &[String], subs: &mut [Substitution]) -> i32 {
+    let mut args = arg::dissolve_options(&args.to_vec());
 
     if args[1..].iter().all(|a| a.starts_with("-")) && subs.is_empty() {
         return declare_print_all(core, &mut args);
@@ -195,7 +200,7 @@ pub fn declare(core: &mut ShellCore, args: &mut Vec<String>, subs: &mut Vec<Subs
 
     let layer = core.db.get_layer_num() - 2;
     for sub in subs {
-        if let Err(e) = set_substitution(core, sub, &mut args.clone(), layer) {
+        if let Err(e) = set_substitution(core, sub, &mut args.to_vec(), layer) {
             e.print(core);
             return 1;
         }
@@ -203,53 +208,63 @@ pub fn declare(core: &mut ShellCore, args: &mut Vec<String>, subs: &mut Vec<Subs
     0
 }
 
-pub fn export(core: &mut ShellCore, args: &mut Vec<String>,
-              subs: &mut Vec<Substitution>) -> i32 {
+pub fn export(core: &mut ShellCore, args: &[String], subs: &mut [Substitution]) -> i32 {
     for sub in subs.iter_mut() {
         let layer = core.db.get_layer_pos(&sub.left_hand.name).unwrap_or(0);
-        if let Err(e) = set_substitution(core, sub, &mut args.clone(), layer) {
+        if let Err(e) = set_substitution(core, sub, &mut args.to_vec(), layer) {
             e.print(core);
             return 1;
         }
         match core.db.get_param(&sub.left_hand.name) {
             Ok(v) => env::set_var(&sub.left_hand.name, v),
-            Err(e) => {e.print(core); return 1;},
+            Err(e) => {
+                e.print(core);
+                return 1;
+            }
         }
     }
     0
 }
 
-pub fn readonly_print(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    let array_opt = arg::consume_option("-a", args);
-    let assoc_opt = arg::consume_option("-A", args);
-    let int_opt = arg::consume_option("-i", args);
+pub fn readonly_print(core: &mut ShellCore, args: &[String]) -> i32 {
+    let mut args = args.to_vec();
+    let array_opt = arg::consume_option("-a", &mut args);
+    let assoc_opt = arg::consume_option("-A", &mut args);
+    let int_opt = arg::consume_option("-i", &mut args);
 
-    let mut names: Vec<String> = core.db.get_keys()
+    let mut names: Vec<String> = core
+        .db
+        .get_keys()
         .iter()
-        .filter(|e| core.db.is_readonly(&e))
+        .filter(|e| core.db.is_readonly(e))
         .map(|e| e.to_string())
         .collect();
 
-    if array_opt { names.retain(|e| core.db.is_array(&e)); }
-    if assoc_opt { names.retain(|e| core.db.is_assoc(&e)); }
-    if int_opt { names.retain(|e| core.db.is_single_num(&e)); }
+    if array_opt {
+        names.retain(|e| core.db.is_array(e));
+    }
+    if assoc_opt {
+        names.retain(|e| core.db.is_assoc(e));
+    }
+    if int_opt {
+        names.retain(|e| core.db.is_single_num(e));
+    }
 
     declare_print(core, &names, &args[0]);
-    return 0;
+    0
 }
 
-pub fn readonly(core: &mut ShellCore, args: &mut Vec<String>,
-                subs: &mut Vec<Substitution>) -> i32 {
-    let mut args = arg::dissolve_options(args);
+pub fn readonly(core: &mut ShellCore, args: &[String], subs: &mut [Substitution]) -> i32 {
+    let args = arg::dissolve_options(&args.to_vec());
 
     if subs.is_empty() {
-        return readonly_print(core, &mut args);
+        return readonly_print(core, &args);
     }
 
     for sub in subs {
         let layer = core.db.get_layer_pos(&sub.left_hand.name).unwrap_or(0);
 
-        if let Err(e) = set_substitution(core, sub, &mut args.clone(), layer) {
+        if let Err(e) = set_substitution(core, sub, &mut args.to_vec(), layer) {
             e.print(core);
             return 1;
         }

--- a/src/core/builtins/printf.rs
+++ b/src/core/builtins/printf.rs
@@ -1,10 +1,10 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{error, Feeder, ShellCore};
+use crate::elements::substitution::Substitution;
 use crate::error::arith::ArithError;
 use crate::error::exec::ExecError;
-use crate::elements::substitution::Substitution;
+use crate::{error, Feeder, ShellCore};
 use std::io::{stdout, Write};
 
 #[derive(Debug, Clone)]
@@ -25,10 +25,7 @@ enum PrintfToken {
 
 impl PrintfToken {
     fn continue_(&self) -> bool {
-        match self {
-            Self::Normal(_) | Self::EscapedChar(_) => false,
-            _ => true,
-        }
+        !matches!(self, Self::Normal(_) | Self::EscapedChar(_))
     }
 
     fn to_int(s: &String) -> Result<isize, ExecError> {
@@ -46,10 +43,8 @@ impl PrintfToken {
     }
 
     //TODO: implement!
-    fn padding_float(_: &mut String, fmt: &mut String) {
-        if fmt.is_empty() {
-            return;
-        }
+    fn padding_float(_: &mut String, fmt: &mut str) {
+        if fmt.is_empty() {}
     }
 
     fn padding(s: &mut String, fmt: &mut String, is_int: bool) {
@@ -68,7 +63,7 @@ impl PrintfToken {
             padding = fmt.remove(0);
         }
 
-        if ! is_int {
+        if !is_int {
             padding = ' ';
         }
 
@@ -92,95 +87,106 @@ impl PrintfToken {
         }
     }
 
-    fn to_string(&mut self, args: &mut Vec<String>) -> Result<String, ExecError> {
+    fn to_string(&self, args: &[String], index: &mut usize) -> Result<String, ExecError> {
         match self {
             Self::DI(fmt) => {
-                let mut a = pop(args);
+                let mut a = get_arg(args, index);
                 Self::padding(&mut a, &mut fmt.clone(), true);
                 Ok(a)
-            },
+            }
             Self::U(fmt) => {
-                let mut a = pop(args);
+                let mut a = get_arg(args, index);
                 if a.starts_with("-") {
                     a.remove(0);
                     let mut num = a.parse::<u64>()?;
-                    num = std::u64::MAX - num + 1;
+                    num = u64::MAX - num + 1;
                     let mut a = num.to_string();
                     Self::padding(&mut a, &mut fmt.clone(), true);
                     Ok(a)
-                }else{
+                } else {
                     Self::padding(&mut a, &mut fmt.clone(), true);
                     Ok(a)
                 }
-            },
+            }
             Self::F(fmt) => {
-                let mut a = format!("{:.6}", Self::to_float(&pop(args))?);
+                let mut a = format!("{:.6}", Self::to_float(&get_arg(args, index))?);
                 Self::padding_float(&mut a, &mut fmt.clone());
                 Ok(a)
-            },
+            }
             Self::S(fmt) => {
-                let mut a = pop(args);
+                let mut a = get_arg(args, index);
                 Self::padding(&mut a, &mut fmt.clone(), false);
                 Ok(a)
-            },
+            }
             Self::B(fmt) => {
-                let mut a = replace_escape(&pop(args));
+                let mut a = replace_escape(&get_arg(args, index));
                 Self::padding(&mut a, &mut fmt.clone(), false);
                 Ok(a)
-            },
+            }
             Self::X(fmt) => {
-                let mut a = format!("{:x}", Self::to_int(&pop(args))?);
+                let mut a = format!("{:x}", Self::to_int(&get_arg(args, index))?);
                 Self::padding(&mut a, &mut fmt.clone(), true);
                 Ok(a)
-            },
+            }
             Self::O(fmt) => {
-                let mut a = format!("{:o}", Self::to_int(&pop(args))?);
+                let mut a = format!("{:o}", Self::to_int(&get_arg(args, index))?);
                 Self::padding(&mut a, &mut fmt.clone(), true);
                 Ok(a)
-            },
+            }
             Self::LargeX(fmt) => {
-                let mut a = format!("{:X}", Self::to_int(&pop(args))?);
+                let mut a = format!("{:X}", Self::to_int(&get_arg(args, index))?);
                 Self::padding(&mut a, &mut fmt.clone(), true);
                 Ok(a)
-            },
+            }
             Self::Q => {
-                let a = pop(args);
-                let q = a.replace("\\", "\\\\").replace("$", "\\$").replace("|", "\\|")
-                    .replace("\"", "\\\"").replace("'", "\\\'").replace("~", "\\~")
-                    .replace("(", "\\(").replace(")", "\\)")
-                    .replace("{", "\\{").replace("}", "\\}")
-                    .replace("!", "\\!").replace("&", "\\&");
+                let a = get_arg(args, index);
+                let q = a
+                    .replace("\\", "\\\\")
+                    .replace("$", "\\$")
+                    .replace("|", "\\|")
+                    .replace("\"", "\\\"")
+                    .replace("'", "\\\'")
+                    .replace("~", "\\~")
+                    .replace("(", "\\(")
+                    .replace(")", "\\)")
+                    .replace("{", "\\{")
+                    .replace("}", "\\}")
+                    .replace("!", "\\!")
+                    .replace("&", "\\&");
                 Ok(q)
-            },
+            }
             Self::Other(s) => {
-                let a = pop(args);
+                let a = get_arg(args, index);
                 let formatted = match sprintf::sprintf!(&s, a) {
                     Ok(res) => res,
                     Err(e) => {
                         let msg = format!("{} {} {}", &e, &s, &a);
                         return Err(ExecError::Other(msg));
-                    },
+                    }
                 };
 
                 Ok(formatted)
-            },
+            }
             Self::EscapedChar(c) => Ok(esc_to_str(*c)),
             Self::Normal(s) => Ok(s.clone()),
         }
     }
 }
 
-fn pop(args: &mut Vec<String>) -> String {
-    match args.is_empty() {
-        true  => "".to_string(),
-        false => args.remove(0),
+fn get_arg(args: &[String], index: &mut usize) -> String {
+    if *index < args.len() {
+        let result = args[*index].clone();
+        *index += 1;
+        result
+    } else {
+        "".to_string()
     }
 }
 
 fn esc_to_str(ch: char) -> String {
     match ch {
         'a' => char::from(7).to_string(),
-        'b' =>  char::from(8).to_string(),
+        'b' => char::from(8).to_string(),
         'e' | 'E' => char::from(27).to_string(),
         'f' => char::from(12).to_string(),
         'n' => "\n".to_string(),
@@ -203,7 +209,7 @@ fn replace_escape(s: &str) -> String {
             if esc {
                 ans.push_str(&esc_to_str(ch));
             }
-            esc = ! esc;
+            esc = !esc;
             continue;
         }
 
@@ -226,7 +232,7 @@ fn scanner_normal(remaining: &str) -> usize {
 }
 
 fn scanner_escaped_char(remaining: &str) -> usize {
-    if ! remaining.starts_with("\\") {
+    if !remaining.starts_with("\\") {
         return 0;
     }
 
@@ -239,7 +245,7 @@ fn scanner_escaped_char(remaining: &str) -> usize {
 fn scanner_format_num(remaining: &str) -> usize {
     let mut ans = 0;
     for c in remaining.chars() {
-        if ! "-.".contains(c) && (c < '0' || c > '9') {
+        if !"-.".contains(c) && !c.is_ascii_digit() {
             break;
         }
 
@@ -252,7 +258,7 @@ fn parse(pattern: &str) -> Vec<PrintfToken> {
     let mut remaining = pattern.to_string();
     let mut ans = vec![];
 
-    while ! remaining.is_empty() {
+    while !remaining.is_empty() {
         let len = scanner_normal(&remaining);
         if len > 0 {
             let tail = remaining.split_off(len);
@@ -270,7 +276,7 @@ fn parse(pattern: &str) -> Vec<PrintfToken> {
 
         if remaining.starts_with("%") {
             remaining.remove(0); // %
-                               
+
             let mut num_part = String::new();
             let len = scanner_format_num(&remaining);
             if len > 0 {
@@ -290,8 +296,8 @@ fn parse(pattern: &str) -> Vec<PrintfToken> {
                 Some('x') => PrintfToken::X(num_part),
                 Some('X') => PrintfToken::LargeX(num_part),
                 Some('q') => PrintfToken::Q,
-                Some(c)   => PrintfToken::Other("%".to_owned() + &num_part + &c.to_string()),
-                None      => PrintfToken::Normal("%".to_string()),
+                Some(c) => PrintfToken::Other("%".to_owned() + &num_part + &c.to_string()),
+                None => PrintfToken::Normal("%".to_string()),
             };
 
             remaining.remove(0);
@@ -302,8 +308,9 @@ fn parse(pattern: &str) -> Vec<PrintfToken> {
     ans
 }
 
-fn format(pattern: &str, args: &mut Vec<String>) -> Result<String, ExecError> {
+fn format(pattern: &str, args: &[String]) -> Result<String, ExecError> {
     let mut ans = String::new();
+    let mut index = 0;
 
     let mut tokens = parse(pattern);
     let mut fin = true;
@@ -312,29 +319,28 @@ fn format(pattern: &str, args: &mut Vec<String>) -> Result<String, ExecError> {
         if tok.continue_() {
             fin = false;
         }
-        ans += &tok.to_string(args)?;
+        ans += &tok.to_string(args, &mut index)?;
     }
 
-    if ! args.is_empty() && ! fin {
-        if let Ok(s) = format(pattern, args) {
+    if index < args.len() && !fin {
+        if let Ok(s) = format(pattern, &args[index..]) {
             ans += &s;
         }
     }
     Ok(ans)
 }
 
-fn arg_check(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    if args.len() < 2 || args[1] == "--help"
-    || args[1] == "-v" && args.len() == 3 {
-        let msg = format!("printf: usage: printf [-v var] format [arguments]");
+fn arg_check(core: &mut ShellCore, args: &[String]) -> i32 {
+    if args.len() < 2 || args[1] == "--help" || args[1] == "-v" && args.len() == 3 {
+        let msg = "printf: usage: printf [-v var] format [arguments]".to_string();
         error::print(&msg, core);
         return 2;
     }
 
     if args[1] == "-v" && args.len() == 2 {
-        let msg = format!("printf: -v: option requires an argument");
+        let msg = "printf: -v: option requires an argument".to_string();
         error::print(&msg, core);
-        let msg = format!("printf: usage: printf [-v var] format [arguments]");
+        let msg = "printf: usage: printf [-v var] format [arguments]".to_string();
         error::print(&msg, core);
         return 2;
     }
@@ -342,17 +348,15 @@ fn arg_check(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     0
 }
 
-fn printf_v(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    if args[3] == "--" {
-        args.remove(3);
-    }
+fn printf_v(core: &mut ShellCore, args: &[String]) -> i32 {
+    let (pattern_idx, args_start) = if args[3] == "--" { (4, 5) } else { (3, 4) };
 
-    let s = match format(&args[3], &mut args[4..].to_vec()) {
+    let s = match format(&args[pattern_idx], &args[args_start..]) {
         Ok(ans) => ans,
         Err(e) => {
             let msg = String::from(&e);
             return super::error_exit(1, "printf", &msg, core);
-        },
+        }
     };
 
     if args[2].contains("[") {
@@ -362,7 +366,7 @@ fn printf_v(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
                 let msg = String::from(&e);
                 return super::error_exit(2, "printf", &msg, core);
             }
-        }else{
+        } else {
             return 1;
         }
         return 0;
@@ -372,12 +376,12 @@ fn printf_v(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
         return super::error_exit(2, "printf", &msg, core);
     }
 
-    return 0;
+    0
 }
 
-pub fn printf(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn printf(core: &mut ShellCore, args: &[String]) -> i32 {
     match arg_check(core, args) {
-        0 => {},
+        0 => {}
         n => return n,
     }
 
@@ -385,13 +389,13 @@ pub fn printf(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
         return printf_v(core, args);
     }
 
-    let s = match format(&args[1], &mut args[2..].to_vec()) {
+    let s = match format(&args[1], &args[2..]) {
         Ok(ans) => ans,
         Err(e) => {
-            let msg = format!("printf: {:?}", e);
+            let msg = format!("printf: {e:?}");
             error::print(&msg, core);
             return 1;
-        },
+        }
     };
     print!("{}", &s);
     stdout().flush().unwrap();

--- a/src/core/builtins/pwd.rs
+++ b/src/core/builtins/pwd.rs
@@ -4,19 +4,21 @@
 
 use crate::ShellCore;
 
-pub fn pwd(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    if args.len() == 1 || &args[1][..1] != "-" { // $ pwd, $ pwd aaa
+pub fn pwd(core: &mut ShellCore, args: &[String]) -> i32 {
+    if args.len() == 1 || &args[1][..1] != "-" {
+        // $ pwd, $ pwd aaa
         return show_pwd(core, false);
     }
 
-    match args[1].as_str() { //$pwd -L, pwd -P, pwd -aaaa
+    match args[1].as_str() {
+        //$pwd -L, pwd -P, pwd -aaaa
         "-P" => show_pwd(core, true), // シンボリックリンク名を解決して表示
         "-L" => show_pwd(core, false), // シンボリックリンク名をそのまま表示（bash default）
         _ => {
             eprintln!("sush: pwd: {}: invalid option", &args[1]);
             eprintln!("pwd: usage: pwd [-LP]");
             1
-        },
+        }
     }
 }
 

--- a/src/core/builtins/source.rs
+++ b/src/core/builtins/source.rs
@@ -1,15 +1,13 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{file_check, Script, ShellCore, Feeder};
 use crate::error::parse::ParseError;
+use crate::{file_check, Feeder, Script, ShellCore};
 
-fn check_error(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
-    if core.db.flags.contains('r') {
-        if args[1].contains('/') {
-            let msg = format!("{}: restricted", &args[1]);
-            return super::error_exit(1, &args[0], &msg, core);
-        }
+fn check_error(core: &mut ShellCore, args: &[String]) -> i32 {
+    if core.db.flags.contains('r') && args[1].contains('/') {
+        let msg = format!("{}: restricted", &args[1]);
+        return super::error_exit(1, &args[0], &msg, core);
     }
 
     if args.len() < 2 {
@@ -25,7 +23,7 @@ fn check_error(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     0
 }
 
-pub fn source(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn source(core: &mut ShellCore, args: &[String]) -> i32 {
     let check = check_error(core, args);
     if check != 0 {
         return check;
@@ -42,7 +40,7 @@ pub fn source(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
         Err(e) => {
             e.print(core);
             return 1;
-        },
+        }
     };
 
     core.source_function_level += 1;
@@ -52,20 +50,17 @@ pub fn source(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
     let _ = core.db.set_array("BASH_SOURCE", Some(source.clone()), None);
 
     feeder.main_feeder = true;
-    loop {
-        match feeder.feed_line(core) {
-            Ok(()) => {}, 
-            _ => break,
-        }
-
+    while let Ok(()) = feeder.feed_line(core) {
         if core.return_flag {
             feeder.consume(feeder.len());
         }
 
-        match Script::parse(&mut feeder, core, false){
-            Ok(Some(mut s)) => {let _ = s.exec(core); },
+        match Script::parse(&mut feeder, core, false) {
+            Ok(Some(mut s)) => {
+                let _ = s.exec(core);
+            }
             Err(e) => e.print(core),
-            _ => { },
+            _ => {}
         }
     }
 

--- a/src/core/builtins/trap.rs
+++ b/src/core/builtins/trap.rs
@@ -2,36 +2,37 @@
 //SPDX-FileCopyrightText: 2023 @caro@mi.shellgei.org
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
-use crate::signal;
 use crate::error::exec::ExecError;
+use crate::signal;
+use crate::ShellCore;
 use nix::sys::signal::Signal;
+use signal_hook::iterator::Signals;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
 use std::{thread, time};
-use signal_hook::iterator::Signals;
 
-pub fn trap(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn trap(core: &mut ShellCore, args: &[String]) -> i32 {
     if args.len() == 1 {
         for e in &core.traplist {
             if e.0 == 0 {
                 println!("trap -- '{}' EXIT", &e.1);
-            }else if let Ok(s) = Signal::try_from(e.0) {
+            } else if let Ok(s) = Signal::try_from(e.0) {
                 println!("trap -- '{}' {}", &e.1, &s);
             }
         }
         return 0;
     }
 
-    if args.len() < 3 { // TODO: print the list of trap entries if args.len() == 1
+    if args.len() < 3 {
+        // TODO: print the list of trap entries if args.len() == 1
         eprintln!("trap: usage: trap arg signal_spec ...");
         return 2;
     }
 
     let forbiddens = Vec::from(signal_hook::consts::FORBIDDEN);
-    let signals = match args_to_nums(&args[2..], &forbiddens){
+    let signals = match args_to_nums(&args[2..], &forbiddens) {
         Ok(v) => v,
         Err(e) => {
             e.print(core);
@@ -53,33 +54,34 @@ pub fn trap(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
             continue;
         };
 
-        let msg = format!("trap: {}: invalid signal specification", n);
+        let msg = format!("trap: {n}: invalid signal specification");
         return super::error_exit(1, &args[0], &msg, core);
     }
 
-    if ! valid_signals.is_empty() {
+    if !valid_signals.is_empty() {
         for n in &valid_signals {
-            core.traplist.push( (*n, args[1].to_string() ) );
+            core.traplist.push((*n, args[1].to_string()));
         }
         run_thread(valid_signals, &args[1], core);
     }
 
     if exit {
-        core.traplist.push( (0, args[1].to_string() ) );
+        core.traplist.push((0, args[1].to_string()));
         core.exit_script = args[1].clone();
     }
 
     0
 }
 
-fn run_thread(signal_nums: Vec<i32>, script: &String, core: &mut ShellCore) {
-    core.trapped.push((Arc::new(AtomicBool::new(false)), script.clone()));
+fn run_thread(signal_nums: Vec<i32>, script: &str, core: &mut ShellCore) {
+    core.trapped
+        .push((Arc::new(AtomicBool::new(false)), script.to_string()));
 
     let trap = Arc::clone(&core.trapped.last().unwrap().0);
 
     thread::spawn(move || {
-        let mut signals = Signals::new(signal_nums.clone())
-                          .expect("sush(fatal): cannot prepare signal data");
+        let mut signals =
+            Signals::new(signal_nums.clone()).expect("sush(fatal): cannot prepare signal data");
 
         loop {
             thread::sleep(time::Duration::from_millis(5));
@@ -92,7 +94,7 @@ fn run_thread(signal_nums: Vec<i32>, script: &String, core: &mut ShellCore) {
     });
 }
 
-fn arg_to_num(arg: &str, forbiddens: &Vec<i32>) -> Result<i32, ExecError> {
+fn arg_to_num(arg: &str, forbiddens: &[i32]) -> Result<i32, ExecError> {
     if arg == "EXIT" || arg == "0" {
         return Ok(0);
     }
@@ -107,15 +109,19 @@ fn arg_to_num(arg: &str, forbiddens: &Vec<i32>) -> Result<i32, ExecError> {
 
     if let Ok(n) = arg.parse::<i32>() {
         if forbiddens.contains(&n) {
-            return Err(ExecError::Other(format!("trap: {}: forbidden signal for trap", arg)));
+            return Err(ExecError::Other(format!(
+                "trap: {arg}: forbidden signal for trap"
+            )));
         }
         return Ok(n);
     }
 
-    return Err(ExecError::Other(format!("trap: {}: invalid signal specification", arg)));
+    Err(ExecError::Other(format!(
+        "trap: {arg}: invalid signal specification"
+    )))
 }
 
-fn args_to_nums(args: &[String], forbiddens: &Vec<i32>) -> Result<Vec<i32>, ExecError> {
+fn args_to_nums(args: &[String], forbiddens: &[i32]) -> Result<Vec<i32>, ExecError> {
     let mut ans = vec![];
     for a in args {
         let n = arg_to_num(a, forbiddens)?;

--- a/src/core/builtins/type_.rs
+++ b/src/core/builtins/type_.rs
@@ -2,8 +2,8 @@
 //SPDX-FileCopyrightText: 2023 @caro@mi.shellgei.org
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{file_check, ShellCore, utils};
 use crate::utils::{arg, file};
+use crate::{file_check, utils, ShellCore};
 
 fn type_no_opt_sub(core: &mut ShellCore, com: &String) -> i32 {
     if core.aliases.contains_key(com) {
@@ -20,7 +20,7 @@ fn type_no_opt_sub(core: &mut ShellCore, com: &String) -> i32 {
         return 0;
     }
     if core.builtins.contains_key(com) {
-        println!("{} is a shell builtin", com);
+        println!("{com} is a shell builtin");
         return 0;
     }
     if let Some(path) = file::search_command(com) {
@@ -28,7 +28,7 @@ fn type_no_opt_sub(core: &mut ShellCore, com: &String) -> i32 {
         return 0;
     }
     if file_check::is_executable(com) {
-        println!("{} is {}", com, com);
+        println!("{com} is {com}");
         return 0;
     }
     1
@@ -37,23 +37,23 @@ fn type_no_opt_sub(core: &mut ShellCore, com: &String) -> i32 {
 fn type_no_opt(core: &mut ShellCore, args: &[String]) -> i32 {
     let mut exit_status = 0;
     for a in args {
-         exit_status += type_no_opt_sub(core, a);
+        exit_status += type_no_opt_sub(core, a);
     }
     if exit_status > 1 {
         exit_status = 1;
     }
-    return exit_status;
+    exit_status
 }
 
 fn type_t(core: &mut ShellCore, args: &[String]) -> i32 {
     let mut exit_status = 0;
     for a in args {
-         exit_status += type_t_sub(core, a);
+        exit_status += type_t_sub(core, a);
     }
     if exit_status > 1 {
         exit_status = 1;
     }
-    return exit_status;
+    exit_status
 }
 
 fn type_t_sub(core: &mut ShellCore, com: &String) -> i32 {
@@ -73,8 +73,7 @@ fn type_t_sub(core: &mut ShellCore, com: &String) -> i32 {
         println!("builtin");
         return 0;
     }
-    if file::search_command(com).is_some()
-    || file_check::is_executable(com) {
+    if file::search_command(com).is_some() || file_check::is_executable(com) {
         println!("file");
         return 0;
     }
@@ -85,30 +84,31 @@ fn type_t_sub(core: &mut ShellCore, com: &String) -> i32 {
 fn type_p(core: &mut ShellCore, args: &[String]) -> i32 {
     let mut exit_status = 0;
     for a in args {
-         exit_status += type_p_sub(core, a);
+        exit_status += type_p_sub(core, a);
     }
     if exit_status > 1 {
         exit_status = 1;
     }
-    return exit_status;
+    exit_status
 }
 
 fn type_large_p(core: &mut ShellCore, args: &[String]) -> i32 {
     let mut exit_status = 0;
     for a in args {
-         exit_status += type_large_p_sub(core, a);
+        exit_status += type_large_p_sub(core, a);
     }
     if exit_status > 1 {
         exit_status = 1;
     }
-    return exit_status;
+    exit_status
 }
 
 fn type_p_sub(core: &mut ShellCore, com: &String) -> i32 {
-    if core.aliases.contains_key(com) 
-    || core.db.functions.contains_key(com)
-    || utils::reserved(com)
-    || core.builtins.contains_key(com) {
+    if core.aliases.contains_key(com)
+        || core.db.functions.contains_key(com)
+        || utils::reserved(com)
+        || core.builtins.contains_key(com)
+    {
         return 0;
     }
 
@@ -117,7 +117,7 @@ fn type_p_sub(core: &mut ShellCore, com: &String) -> i32 {
         return 0;
     }
     if file_check::is_executable(com) {
-        println!("{}", com);
+        println!("{com}");
         return 0;
     }
     1
@@ -125,10 +125,11 @@ fn type_p_sub(core: &mut ShellCore, com: &String) -> i32 {
 
 fn type_large_p_sub(core: &mut ShellCore, com: &String) -> i32 {
     let mut es = 1;
-    if core.aliases.contains_key(com) 
-    || core.db.functions.contains_key(com)
-    || utils::reserved(com)
-    || core.builtins.contains_key(com) {
+    if core.aliases.contains_key(com)
+        || core.db.functions.contains_key(com)
+        || utils::reserved(com)
+        || core.builtins.contains_key(com)
+    {
         es = 0;
     }
 
@@ -137,18 +138,18 @@ fn type_large_p_sub(core: &mut ShellCore, com: &String) -> i32 {
         return 0;
     }
     if file_check::is_executable(com) {
-        println!("{}", com);
+        println!("{com}");
         return 0;
     }
     es
 }
 
-pub fn type_(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn type_(core: &mut ShellCore, args: &[String]) -> i32 {
     if args.len() < 2 {
         return 0;
     }
 
-    let mut args = arg::dissolve_options(args);
+    let mut args = arg::dissolve_options(&args.to_vec());
     if arg::consume_option("-t", &mut args) {
         if args[1] == "--" {
             args.remove(1);

--- a/src/core/builtins/unset.rs
+++ b/src/core/builtins/unset.rs
@@ -1,8 +1,8 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{Feeder, ShellCore};
 use crate::elements::substitution::variable::Variable;
+use crate::{Feeder, ShellCore};
 
 fn unset_all(core: &mut ShellCore, name: &str) -> i32 {
     core.db.unset(name);
@@ -19,7 +19,7 @@ fn unset_function(core: &mut ShellCore, name: &str) -> i32 {
     0
 }
 
-pub fn unset(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
+pub fn unset(core: &mut ShellCore, args: &[String]) -> i32 {
     if args.len() < 2 {
         return 0;
     }
@@ -29,18 +29,18 @@ pub fn unset(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
             if args.len() > 2 {
                 return unset_function(core, &args[2]);
             }
-        },
+        }
         "-v" => {
             if args.len() > 2 {
                 return unset_var(core, &args[2]);
             }
-        },
+        }
         name => {
-            if ! name.contains("[") {
+            if !name.contains("[") {
                 return unset_all(core, name);
             }
 
-            let mut f = Feeder::new(&(name.to_owned()));
+            let mut f = Feeder::new(name);
             if let Ok(Some(mut sub)) = Variable::parse(&mut f, core) {
                 if let Ok(Some(key)) = sub.get_index(core, false, false) {
                     let nm = sub.name.clone();
@@ -51,7 +51,7 @@ pub fn unset(core: &mut ShellCore, args: &mut Vec<String>) -> i32 {
 
             let msg = format!("{}: invalid variable", &name);
             return super::error_exit(1, &args[0], &msg, core);
-        },
+        }
     }
     0
 }

--- a/src/core/database.rs
+++ b/src/core/database.rs
@@ -6,18 +6,18 @@ mod database_checker;
 mod database_getter;
 mod database_setter;
 
-use crate::{env, exit};
-use crate::elements::command::function_def::FunctionDefinition;
-use std::collections::HashMap;
-use self::data::Data;
-use self::data::assoc::AssocData;
-use self::data::single::SingleData;
 use self::data::array::ArrayData;
 use self::data::array_int::IntArrayData;
-use self::data::assoc_int::IntAssocData;
 use self::data::array_uninit::UninitArray;
+use self::data::assoc::AssocData;
+use self::data::assoc_int::IntAssocData;
 use self::data::assoc_uninit::UninitAssoc;
+use self::data::single::SingleData;
 use self::data::single_int::IntData;
+use self::data::Data;
+use crate::elements::command::function_def::FunctionDefinition;
+use crate::{env, exit};
+use std::collections::HashMap;
 //use self::data::special::SpecialData;
 
 #[derive(Debug, Default)]
@@ -56,7 +56,6 @@ impl DataBase {
     fn solve_layer(&mut self, name: &str) -> usize {
         self.get_layer_pos(name).unwrap_or(0)
     }
-
 
     pub fn push_local(&mut self) {
         self.params.push(HashMap::new());
@@ -112,7 +111,7 @@ impl DataBase {
     pub fn print(&mut self, name: &str) {
         if let Some(d) = self.get_ref(name) {
             d.print_with_name(name, false);
-        }else if let Some(f) = self.functions.get(name) {
+        } else if let Some(f) = self.functions.get(name) {
             println!("{}", &f.text);
         }
     }
@@ -120,7 +119,7 @@ impl DataBase {
     pub fn declare_print(&mut self, name: &str) {
         if let Some(d) = self.get_ref(name) {
             d.print_with_name(name, true);
-        }else if let Some(f) = self.functions.get(name) {
+        } else if let Some(f) = self.functions.get(name) {
             println!("{}", &f.text);
         }
     }

--- a/src/core/database/data.rs
+++ b/src/core/database/data.rs
@@ -7,8 +7,8 @@ pub mod array_uninit;
 pub mod assoc;
 pub mod assoc_int;
 pub mod assoc_uninit;
-pub mod epochseconds;
 pub mod epochrealtime;
+pub mod epochseconds;
 pub mod random;
 pub mod seconds;
 pub mod single;
@@ -24,14 +24,14 @@ use std::fmt::Debug;
 fn to_int(s: &str) -> Result<isize, ExecError> {
     match s.parse::<isize>() {
         Ok(n) => Ok(n),
-        Err(e) => return Err(ArithError::OperandExpected(e.to_string()).into()),
+        Err(e) => Err(ArithError::OperandExpected(e.to_string()).into()),
     }
 }
 
 fn to_key(s: &str) -> Result<usize, ExecError> {
     match s.parse::<usize>() {
         Ok(n) => Ok(n),
-        Err(_) => return Err(ExecError::ArrayIndexInvalid(s.to_string())),
+        Err(_) => Err(ExecError::ArrayIndexInvalid(s.to_string())),
     }
 }
 
@@ -41,7 +41,7 @@ impl Debug for dyn Data {
     }
 }
 
-impl Clone for Box::<dyn Data> {
+impl Clone for Box<dyn Data> {
     fn clone(&self) -> Box<dyn Data> {
         self.boxed_clone()
     }
@@ -53,28 +53,36 @@ pub trait Data {
 
     fn print_with_name(&self, name: &str, declare_print: bool) {
         if self.is_special() {
-            println!("{}", name);
+            println!("{name}");
             return;
         }
 
         let body = self.print_body();
-        if ! self.is_initialized() {
-            println!("{}", name);
-        }else if declare_print && self.is_single() {
-            println!("{}=\"{}\"", name, body);
-        }else{
-            println!("{}={}", name, body);
+        if !self.is_initialized() {
+            println!("{name}");
+        } else if declare_print && self.is_single() {
+            println!("{name}=\"{body}\"");
+        } else {
+            println!("{name}={body}");
         }
     }
 
-    fn is_initialized(&self) -> bool {true}
+    fn is_initialized(&self) -> bool {
+        true
+    }
 
     //fn push_elems(&mut self, _: Vec<String>) -> Result<(), ExecError> { Err(ExecError::Other("Undefined call push_elems".to_string())) }
 
     fn clear(&mut self) {}
-    fn set_as_single(&mut self, _: &str) -> Result<(), ExecError> {Err(ExecError::Other("Undefined call set_as_single".to_string()))}
-    fn append_as_single(&mut self, _: &str) -> Result<(), ExecError> {Err(ExecError::Other("Undefined call set_as_single".to_string()))}
-    fn get_as_single_num(&mut self) -> Result<isize, ExecError> {Err(ExecError::Other("not a single variable".to_string()))}
+    fn set_as_single(&mut self, _: &str) -> Result<(), ExecError> {
+        Err(ExecError::Other("Undefined call set_as_single".to_string()))
+    }
+    fn append_as_single(&mut self, _: &str) -> Result<(), ExecError> {
+        Err(ExecError::Other("Undefined call set_as_single".to_string()))
+    }
+    fn get_as_single_num(&mut self) -> Result<isize, ExecError> {
+        Err(ExecError::Other("not a single variable".to_string()))
+    }
 
     fn set_as_array(&mut self, _: &str, _: &str) -> Result<(), ExecError> {
         Err(ExecError::Other("not an array".to_string()))
@@ -90,37 +98,40 @@ pub trait Data {
         Err(ExecError::Other("not an associative table".to_string()))
     }
 
-    fn get_as_single(&mut self) -> Result<String, ExecError> {Err(ExecError::Other("not a single variable".to_string()))}
-    fn get_as_array(&mut self, key: &str, _: &str) -> Result<String, ExecError> { //TODO: change to ArithError
+    fn get_as_single(&mut self) -> Result<String, ExecError> {
+        Err(ExecError::Other("not a single variable".to_string()))
+    }
+    fn get_as_array(&mut self, key: &str, _: &str) -> Result<String, ExecError> {
+        //TODO: change to ArithError
         let err = ArithError::OperandExpected(key.to_string());
-        Err(ExecError::ArithError(key.to_string(), err)) 
+        Err(ExecError::ArithError(key.to_string(), err))
     }
     fn get_as_assoc(&mut self, key: &str) -> Result<String, ExecError> {
         let err = ArithError::OperandExpected(key.to_string());
-        Err(ExecError::ArithError(key.to_string(), err)) 
+        Err(ExecError::ArithError(key.to_string(), err))
     }
 
     fn get_as_array_or_assoc(&mut self, pos: &str, ifs: &str) -> Result<String, ExecError> {
         if self.is_assoc() {
             return match self.get_as_assoc(pos) {
-                Ok(d)  => Ok(d),
+                Ok(d) => Ok(d),
                 Err(_) => Ok("".to_string()),
-            }
+            };
         }
         if self.is_array() {
             return match self.get_as_array(pos, ifs) {
-                Ok(d)  => Ok(d),
+                Ok(d) => Ok(d),
                 Err(_) => Ok("".to_string()),
-            }
+            };
         }
 
         if pos == "0" || pos == "*" || pos == "@" {
-            return match self.get_as_single() {
-                Ok(d)  => Ok(d),
+            match self.get_as_single() {
+                Ok(d) => Ok(d),
                 Err(_) => Ok("".to_string()),
             }
-        }else{
-            return Ok("".to_string());
+        } else {
+            Ok("".to_string())
         }
 
         //Err(ExecError::ArrayIndexInvalid(pos.to_string()))
@@ -134,25 +145,42 @@ pub trait Data {
         Err(ExecError::Other("not an array".to_string()))
     }
 
+    fn get_all_indexes_as_array(&mut self) -> Result<Vec<String>, ExecError> {
+        Err(ExecError::Other("not an array".to_string()))
+    }
 
-    fn get_all_indexes_as_array(&mut self) -> Result<Vec<String>, ExecError> {Err(ExecError::Other("not an array".to_string()))}
-
-    fn is_special(&self) -> bool {false}
-    fn is_single(&self) -> bool {false}
-    fn is_single_num(&self) -> bool {false}
-    fn is_assoc(&self) -> bool {false}
-    fn is_array(&self) -> bool {false}
+    fn is_special(&self) -> bool {
+        false
+    }
+    fn is_single(&self) -> bool {
+        false
+    }
+    fn is_single_num(&self) -> bool {
+        false
+    }
+    fn is_assoc(&self) -> bool {
+        false
+    }
+    fn is_array(&self) -> bool {
+        false
+    }
     fn len(&mut self) -> usize;
-    fn index_based_len(&mut self) -> usize {self.len()}
+    fn index_based_len(&mut self) -> usize {
+        self.len()
+    }
 
     fn elem_len(&mut self, key: &str) -> Result<usize, ExecError> {
         match key {
             "0" => Ok(self.len()),
-            _   => Ok(0),
+            _ => Ok(0),
         }
     }
 
-    fn init_as_num(&mut self) -> Result<(), ExecError> {Err(ExecError::Other("Undefined call init_as_num".to_string()))}
+    fn init_as_num(&mut self) -> Result<(), ExecError> {
+        Err(ExecError::Other("Undefined call init_as_num".to_string()))
+    }
 
-    fn remove_elem(&mut self, _: &str) -> Result<(), ExecError> {Err(ExecError::Other("Undefined call remove_elem".to_string()))}
+    fn remove_elem(&mut self, _: &str) -> Result<(), ExecError> {
+        Err(ExecError::Other("Undefined call remove_elem".to_string()))
+    }
 }

--- a/src/core/database/data/array.rs
+++ b/src/core/database/data/array.rs
@@ -1,11 +1,11 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
-use crate::utils;
-use crate::error::exec::ExecError;
-use std::collections::HashMap;
-use super::Data;
 use super::array_uninit::UninitArray;
+use super::Data;
+use crate::error::exec::ExecError;
+use crate::utils;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Default)]
 pub struct ArrayData {
@@ -15,15 +15,17 @@ pub struct ArrayData {
 impl From<Option<Vec<String>>> for ArrayData {
     fn from(v: Option<Vec<String>>) -> Self {
         let mut ans = Self::default();
-        v.unwrap().into_iter()
-         .enumerate()
-         .for_each(|(i, e)| {ans.body.insert(i, e);});
+        v.unwrap().into_iter().enumerate().for_each(|(i, e)| {
+            ans.body.insert(i, e);
+        });
         ans
     }
 }
 
 impl Data for ArrayData {
-    fn boxed_clone(&self) -> Box<dyn Data> { Box::new(self.clone()) }
+    fn boxed_clone(&self) -> Box<dyn Data> {
+        Box::new(self.clone())
+    }
 
     fn print_body(&self) -> String {
         let mut formatted = "(".to_string();
@@ -31,10 +33,10 @@ impl Data for ArrayData {
             let ansi = utils::to_ansi_c(&self.body[&i]);
             if ansi == self.body[&i] {
                 formatted += &format!("[{}]=\"{}\" ", i, &ansi);
-            }else{
+            } else {
                 formatted += &format!("[{}]={} ", i, &ansi);
             }
-        };
+        }
         if formatted.ends_with(" ") {
             formatted.pop();
         }
@@ -42,8 +44,12 @@ impl Data for ArrayData {
         formatted
     }
 
-    fn clear(&mut self) { self.body.clear(); }
-    fn is_initialized(&self) -> bool { true }
+    fn clear(&mut self) {
+        self.body.clear();
+    }
+    fn is_initialized(&self) -> bool {
+        true
+    }
 
     fn set_as_single(&mut self, value: &str) -> Result<(), ExecError> {
         self.body.insert(0, value.to_string());
@@ -53,7 +59,7 @@ impl Data for ArrayData {
     fn append_as_single(&mut self, value: &str) -> Result<(), ExecError> {
         if let Some(v) = self.body.get(&0) {
             self.body.insert(0, v.to_owned() + value);
-        }else {
+        } else {
             self.body.insert(0, value.to_string());
         }
         Ok(())
@@ -85,7 +91,7 @@ impl Data for ArrayData {
         if let Ok(n) = key.parse::<usize>() {
             if let Some(v) = self.body.get(&n) {
                 self.body.insert(n, v.to_owned() + value);
-            }else{
+            } else {
                 self.body.insert(n, value.to_string());
             }
             return Ok(());
@@ -101,8 +107,10 @@ impl Data for ArrayData {
             return Ok(self.values().join(ifs));
         }
 
-        let n = key.parse::<usize>().map_err(|_| ExecError::ArrayIndexInvalid(key.to_string()))?;
-        Ok( self.body.get(&n).unwrap_or(&"".to_string()).clone() )
+        let n = key
+            .parse::<usize>()
+            .map_err(|_| ExecError::ArrayIndexInvalid(key.to_string()))?;
+        Ok(self.body.get(&n).unwrap_or(&"".to_string()).clone())
     }
 
     /*
@@ -134,16 +142,16 @@ impl Data for ArrayData {
         }
 
         let keys = self.keys();
-        let max = *keys.iter().max().unwrap() as usize;
+        let max = *keys.iter().max().unwrap();
         let mut ans = vec![];
-        for i in pos..(max+1) {
+        for i in pos..(max + 1) {
             match self.body.get(&i) {
                 Some(s) => ans.push(s.clone()),
                 None => {
-                    if ! skip_non {
+                    if !skip_non {
                         ans.push("".to_string());
                     }
-                },
+                }
             }
         }
         Ok(ans)
@@ -154,16 +162,23 @@ impl Data for ArrayData {
     }
 
     fn get_as_single(&mut self) -> Result<String, ExecError> {
-        self.body.get(&0).map(|v| Ok(v.clone())).ok_or(ExecError::Other("No entry".to_string()))?
+        self.body
+            .get(&0)
+            .map(|v| Ok(v.clone()))
+            .ok_or(ExecError::Other("No entry".to_string()))?
     }
 
-    fn is_array(&self) -> bool {true}
-    fn len(&mut self) -> usize { self.body.len() }
+    fn is_array(&self) -> bool {
+        true
+    }
+    fn len(&mut self) -> usize {
+        self.body.len()
+    }
 
     fn index_based_len(&mut self) -> usize {
         match self.body.iter().map(|e| e.0).max() {
-            Some(n) => *n+1,
-            None    => 0,
+            Some(n) => *n + 1,
+            None => 0,
         }
     }
 
@@ -172,7 +187,9 @@ impl Data for ArrayData {
             return Ok(self.len());
         }
 
-        let n = key.parse::<usize>().map_err(|_| ExecError::ArrayIndexInvalid(key.to_string()))?;
+        let n = key
+            .parse::<usize>()
+            .map_err(|_| ExecError::ArrayIndexInvalid(key.to_string()))?;
         let s = self.body.get(&n).unwrap_or(&"".to_string()).clone();
 
         Ok(s.chars().count())
@@ -193,76 +210,87 @@ impl Data for ArrayData {
 }
 
 impl ArrayData {
-    pub fn set_new_entry(db_layer: &mut HashMap<String, Box<dyn Data>>, name: &str, v: Option<Vec<String>>)
-    -> Result<(), ExecError> {
+    pub fn set_new_entry(
+        db_layer: &mut HashMap<String, Box<dyn Data>>,
+        name: &str,
+        v: Option<Vec<String>>,
+    ) -> Result<(), ExecError> {
         if v.is_none() {
-            db_layer.insert(name.to_string(), UninitArray{}.boxed_clone());
-        }else {
+            db_layer.insert(name.to_string(), UninitArray {}.boxed_clone());
+        } else {
             db_layer.insert(name.to_string(), Box::new(ArrayData::from(v)));
         }
         Ok(())
     }
 
-    pub fn set_elem(db_layer: &mut HashMap<String, Box<dyn Data>>,
-                        name: &str, pos: usize, val: &String) -> Result<(), ExecError> {
+    pub fn set_elem(
+        db_layer: &mut HashMap<String, Box<dyn Data>>,
+        name: &str,
+        pos: usize,
+        val: &str,
+    ) -> Result<(), ExecError> {
         if let Some(d) = db_layer.get_mut(name) {
             if d.is_array() {
-                if ! d.is_initialized() {
+                if !d.is_initialized() {
                     *d = ArrayData::default().boxed_clone();
                 }
-                
-                return d.set_as_array(&pos.to_string(), val);
-            }else if d.is_assoc() {
+
+                d.set_as_array(&pos.to_string(), val)
+            } else if d.is_assoc() {
                 return d.set_as_assoc(&pos.to_string(), val);
-            }else if d.is_single() {
+            } else if d.is_single() {
                 let data = d.get_as_single()?;
                 ArrayData::set_new_entry(db_layer, name, Some(vec![]))?;
-                
-                if data != "" {
+
+                if !data.is_empty() {
                     Self::set_elem(db_layer, name, 0, &data)?;
                 }
                 Self::set_elem(db_layer, name, pos, val)
-            }else {
+            } else {
                 ArrayData::set_new_entry(db_layer, name, Some(vec![]))?;
                 Self::set_elem(db_layer, name, pos, val)
             }
-        }else{
+        } else {
             ArrayData::set_new_entry(db_layer, name, Some(vec![]))?;
             Self::set_elem(db_layer, name, pos, val)
         }
     }
 
-    pub fn append_elem(db_layer: &mut HashMap<String, Box<dyn Data>>,
-                        name: &str, pos: usize, val: &String) -> Result<(), ExecError> {
+    pub fn append_elem(
+        db_layer: &mut HashMap<String, Box<dyn Data>>,
+        name: &str,
+        pos: usize,
+        val: &str,
+    ) -> Result<(), ExecError> {
         if let Some(d) = db_layer.get_mut(name) {
             if d.is_array() {
-                if ! d.is_initialized() {
+                if !d.is_initialized() {
                     *d = ArrayData::default().boxed_clone();
                 }
 
-                return d.append_to_array_elem(&pos.to_string(), val);
-            }else if d.is_assoc() {
+                d.append_to_array_elem(&pos.to_string(), val)
+            } else if d.is_assoc() {
                 return d.append_to_assoc_elem(&pos.to_string(), val);
-            }else{
+            } else {
                 let data = d.get_as_single()?;
                 ArrayData::set_new_entry(db_layer, name, Some(vec![]))?;
                 Self::append_elem(db_layer, name, 0, &data)?;
                 Self::append_elem(db_layer, name, pos, val)
             }
-        }else{
+        } else {
             ArrayData::set_new_entry(db_layer, name, Some(vec![]))?;
             Self::set_elem(db_layer, name, pos, val)
         }
     }
 
     pub fn values(&self) -> Vec<String> {
-        let mut keys: Vec<usize> = self.body.iter().map(|e| e.0.clone()).collect();
+        let mut keys: Vec<usize> = self.body.iter().map(|e| *e.0).collect();
         keys.sort();
         keys.iter().map(|i| self.body[i].clone()).collect()
     }
 
     pub fn keys(&self) -> Vec<usize> {
-        let mut keys: Vec<usize> = self.body.iter().map(|e| e.0.clone()).collect();
+        let mut keys: Vec<usize> = self.body.iter().map(|e| *e.0).collect();
         keys.sort();
         keys
     }

--- a/src/core/database/data/array_int.rs
+++ b/src/core/database/data/array_int.rs
@@ -1,9 +1,9 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
+use super::Data;
 use crate::error::exec::ExecError;
 use std::collections::HashMap;
-use super::Data;
 
 #[derive(Debug, Clone, Default)]
 pub struct IntArrayData {
@@ -11,13 +11,15 @@ pub struct IntArrayData {
 }
 
 impl Data for IntArrayData {
-    fn boxed_clone(&self) -> Box<dyn Data> { Box::new(self.clone()) }
+    fn boxed_clone(&self) -> Box<dyn Data> {
+        Box::new(self.clone())
+    }
 
     fn print_body(&self) -> String {
         let mut formatted = "(".to_string();
         for i in self.keys() {
             formatted += &format!("[{}]={} ", i, &self.body[&i]);
-        };
+        }
         if formatted.ends_with(" ") {
             formatted.pop();
         }
@@ -25,8 +27,12 @@ impl Data for IntArrayData {
         formatted
     }
 
-    fn clear(&mut self) { self.body.clear(); }
-    fn is_initialized(&self) -> bool { true }
+    fn clear(&mut self) {
+        self.body.clear();
+    }
+    fn is_initialized(&self) -> bool {
+        true
+    }
 
     fn set_as_single(&mut self, value: &str) -> Result<(), ExecError> {
         let n = super::to_int(value)?;
@@ -42,7 +48,7 @@ impl Data for IntArrayData {
 
         if let Some(v) = self.body.get(&0) {
             self.body.insert(0, v + n);
-        }else {
+        } else {
             self.body.insert(0, n);
         }
         Ok(())
@@ -75,7 +81,7 @@ impl Data for IntArrayData {
 
         if let Some(prev) = self.body.get(&key) {
             self.body.insert(key, prev + n);
-        }else{
+        } else {
             self.body.insert(key, n);
         }
         Ok(())
@@ -89,28 +95,29 @@ impl Data for IntArrayData {
             return Ok(self.values().join(ifs));
         }
 
-        let n = key.parse::<usize>()
-                   .map_err(|_| ExecError::ArrayIndexInvalid(key.to_string()))?;
+        let n = key
+            .parse::<usize>()
+            .map_err(|_| ExecError::ArrayIndexInvalid(key.to_string()))?;
 
-        Ok( self.body.get(&n).unwrap_or(&0).to_string() )
+        Ok(self.body.get(&n).unwrap_or(&0).to_string())
     }
 
     fn get_all_as_array(&mut self, skip_none: bool) -> Result<Vec<String>, ExecError> {
         if self.body.is_empty() {
             return Ok(vec![]);
         }
-        
+
         let keys = self.keys();
-        let max = *keys.iter().max().unwrap() as usize;
+        let max = *keys.iter().max().unwrap();
         let mut ans = vec![];
-        for i in 0..(max+1) {
+        for i in 0..(max + 1) {
             match self.body.get(&i) {
                 Some(s) => ans.push(s.to_string()),
                 None => {
-                    if ! skip_none {
+                    if !skip_none {
                         ans.push("".to_string());
                     }
-                },
+                }
             }
         }
         Ok(ans)
@@ -121,18 +128,27 @@ impl Data for IntArrayData {
     }
 
     fn get_as_single(&mut self) -> Result<String, ExecError> {
-        self.body.get(&0).map(|v| Ok(v.to_string())).ok_or(ExecError::Other("No entry".to_string()))?
+        self.body
+            .get(&0)
+            .map(|v| Ok(v.to_string()))
+            .ok_or(ExecError::Other("No entry".to_string()))?
     }
 
-    fn is_array(&self) -> bool {true}
-    fn len(&mut self) -> usize { self.body.len() }
+    fn is_array(&self) -> bool {
+        true
+    }
+    fn len(&mut self) -> usize {
+        self.body.len()
+    }
 
     fn elem_len(&mut self, key: &str) -> Result<usize, ExecError> {
         if key == "@" || key == "*" {
             return Ok(self.len());
         }
 
-        let n = key.parse::<usize>().map_err(|_| ExecError::ArrayIndexInvalid(key.to_string()))?;
+        let n = key
+            .parse::<usize>()
+            .map_err(|_| ExecError::ArrayIndexInvalid(key.to_string()))?;
         let s = self.body.get(&n).unwrap_or(&0).to_string();
 
         Ok(s.chars().count())
@@ -153,15 +169,14 @@ impl Data for IntArrayData {
 }
 
 impl IntArrayData {
-
     pub fn values(&self) -> Vec<String> {
-        let mut keys: Vec<usize> = self.body.iter().map(|e| e.0.clone()).collect();
+        let mut keys: Vec<usize> = self.body.iter().map(|e| *e.0).collect();
         keys.sort();
         keys.iter().map(|i| self.body[i].to_string()).collect()
     }
 
     pub fn keys(&self) -> Vec<usize> {
-        let mut keys: Vec<usize> = self.body.iter().map(|e| e.0.clone()).collect();
+        let mut keys: Vec<usize> = self.body.iter().map(|e| *e.0).collect();
         keys.sort();
         keys
     }

--- a/src/core/database/data/array_uninit.rs
+++ b/src/core/database/data/array_uninit.rs
@@ -1,11 +1,11 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
-use crate::error::exec::ExecError;
 use super::Data;
+use crate::error::exec::ExecError;
 
 #[derive(Debug, Clone, Default)]
-pub struct UninitArray { }
+pub struct UninitArray {}
 
 /*
 impl From<Option<Vec<String>>> for UninitArray {
@@ -15,19 +15,39 @@ impl From<Option<Vec<String>>> for UninitArray {
 }*/
 
 impl Data for UninitArray {
-    fn boxed_clone(&self) -> Box<dyn Data> { Box::new(self.clone()) }
-    fn print_body(&self) -> String {"".to_string()}
-
-    fn clear(&mut self) { }
-    fn is_initialized(&self) -> bool { false }
-    fn get_as_array(&mut self, _: &str, _: &str) -> Result<String, ExecError> {
-        Ok( "".to_string() )
+    fn boxed_clone(&self) -> Box<dyn Data> {
+        Box::new(self.clone())
     }
-    fn get_all_as_array(&mut self, _: bool) -> Result<Vec<String>, ExecError> { Ok(vec![]) }
-    fn get_all_indexes_as_array(&mut self) -> Result<Vec<String>, ExecError> { Ok(vec![]) }
-    fn get_as_single(&mut self) -> Result<String, ExecError> { Ok("".to_string()) }
-    fn is_array(&self) -> bool {true}
-    fn len(&mut self) -> usize { 0 }
-    fn elem_len(&mut self, _: &str) -> Result<usize, ExecError> { Ok(0) }
-    fn remove_elem(&mut self, _: &str) -> Result<(), ExecError> { Ok(()) }
+    fn print_body(&self) -> String {
+        "".to_string()
+    }
+
+    fn clear(&mut self) {}
+    fn is_initialized(&self) -> bool {
+        false
+    }
+    fn get_as_array(&mut self, _: &str, _: &str) -> Result<String, ExecError> {
+        Ok("".to_string())
+    }
+    fn get_all_as_array(&mut self, _: bool) -> Result<Vec<String>, ExecError> {
+        Ok(vec![])
+    }
+    fn get_all_indexes_as_array(&mut self) -> Result<Vec<String>, ExecError> {
+        Ok(vec![])
+    }
+    fn get_as_single(&mut self) -> Result<String, ExecError> {
+        Ok("".to_string())
+    }
+    fn is_array(&self) -> bool {
+        true
+    }
+    fn len(&mut self) -> usize {
+        0
+    }
+    fn elem_len(&mut self, _: &str) -> Result<usize, ExecError> {
+        Ok(0)
+    }
+    fn remove_elem(&mut self, _: &str) -> Result<(), ExecError> {
+        Ok(())
+    }
 }

--- a/src/core/database/data/assoc.rs
+++ b/src/core/database/data/assoc.rs
@@ -1,9 +1,9 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
-use crate::utils;
-use crate::error::exec::ExecError;
 use super::Data;
+use crate::error::exec::ExecError;
+use crate::utils;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Default)]
@@ -14,7 +14,10 @@ pub struct AssocData {
 
 impl From<HashMap<String, String>> for AssocData {
     fn from(hm: HashMap<String, String>) -> Self {
-        Self { body: hm, last: None, }
+        Self {
+            body: hm,
+            last: None,
+        }
     }
 }
 
@@ -31,7 +34,7 @@ impl Data for AssocData {
             let ansi = utils::to_ansi_c(v);
             if ansi == *v {
                 formatted += &format!("[{}]=\"{}\" ", k, &ansi);
-            }else{
+            } else {
                 formatted += &format!("[{}]={} ", k, &ansi);
             }
         }
@@ -43,7 +46,9 @@ impl Data for AssocData {
         formatted
     }
 
-    fn clear(&mut self) { self.body.clear(); }
+    fn clear(&mut self) {
+        self.body.clear();
+    }
 
     fn set_as_assoc(&mut self, key: &str, value: &str) -> Result<(), ExecError> {
         self.body.insert(key.to_string(), value.to_string());
@@ -54,7 +59,7 @@ impl Data for AssocData {
     fn append_to_assoc_elem(&mut self, key: &str, value: &str) -> Result<(), ExecError> {
         if let Some(v) = self.body.get(key) {
             self.body.insert(key.to_string(), v.to_owned() + value);
-        }else{
+        } else {
             self.body.insert(key.to_string(), value.to_string());
         }
         self.last = Some(value.to_string());
@@ -77,11 +82,17 @@ impl Data for AssocData {
             return Ok(s.to_string());
         }
 
-        self.last.clone().ok_or(ExecError::Other("No last input".to_string()))
+        self.last
+            .clone()
+            .ok_or(ExecError::Other("No last input".to_string()))
     }
 
-    fn is_assoc(&self) -> bool {true}
-    fn len(&mut self) -> usize { self.body.len() }
+    fn is_assoc(&self) -> bool {
+        true
+    }
+    fn len(&mut self) -> usize {
+        self.body.len()
+    }
 
     fn elem_len(&mut self, key: &str) -> Result<usize, ExecError> {
         if key == "@" || key == "*" {
@@ -101,16 +112,18 @@ impl Data for AssocData {
         if self.body.is_empty() {
             return Ok(vec![]);
         }
-        
+
         let mut keys = self.keys();
         keys.sort();
         let mut ans = vec![];
         for i in keys {
             match self.body.get(&i) {
                 Some(s) => ans.push(s.clone()),
-                None => if ! skip_none {
-                    ans.push("".to_string());
-                },
+                None => {
+                    if !skip_none {
+                        ans.push("".to_string());
+                    }
+                }
             }
         }
         Ok(ans)
@@ -127,7 +140,7 @@ impl Data for AssocData {
         }
 
         self.body.remove(key);
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -141,15 +154,19 @@ impl AssocData {
     pub fn set_elem(db_layer: &mut HashMap<String, Box<dyn Data>>, name: &str,
                      key: &String, val: &String) -> Result<(), ExecError> {
         match db_layer.get_mut(name) {
-            Some(v) => v.set_as_assoc(key, val), 
+            Some(v) => v.set_as_assoc(key, val),
             _ => Err(ExecError::Other("TODO".to_string())),
         }
     }*/
 
-    pub fn append_elem(db_layer: &mut HashMap<String, Box<dyn Data>>, name: &str,
-                     key: &String, val: &String) -> Result<(), ExecError> {
+    pub fn append_elem(
+        db_layer: &mut HashMap<String, Box<dyn Data>>,
+        name: &str,
+        key: &str,
+        val: &str,
+    ) -> Result<(), ExecError> {
         match db_layer.get_mut(name) {
-            Some(v) => v.append_to_assoc_elem(key, val), 
+            Some(v) => v.append_to_assoc_elem(key, val),
             _ => Err(ExecError::Other("TODO".to_string())),
         }
     }

--- a/src/core/database/data/assoc_int.rs
+++ b/src/core/database/data/assoc_int.rs
@@ -1,9 +1,9 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
-use crate::utils;
-use crate::error::exec::ExecError;
 use super::Data;
+use crate::error::exec::ExecError;
+use crate::utils;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Default)]
@@ -32,7 +32,7 @@ impl Data for IntAssocData {
             let ansi = utils::to_ansi_c(v);
             if ansi == *v {
                 formatted += &format!("[{}]=\"{}\" ", k, &ansi);
-            }else{
+            } else {
                 formatted += &format!("[{}]={} ", k, &ansi);
             }
         }
@@ -41,7 +41,9 @@ impl Data for IntAssocData {
         formatted
     }
 
-    fn clear(&mut self) { self.body.clear(); }
+    fn clear(&mut self) {
+        self.body.clear();
+    }
 
     fn set_as_assoc(&mut self, key: &str, value: &str) -> Result<(), ExecError> {
         let n = super::to_int(value)?;
@@ -55,7 +57,7 @@ impl Data for IntAssocData {
 
         if let Some(v) = self.body.get(key) {
             self.body.insert(key.to_string(), v + n);
-        }else{
+        } else {
             self.body.insert(key.to_string(), n);
         }
         self.last = Some(value.to_string());
@@ -78,18 +80,24 @@ impl Data for IntAssocData {
             return Ok(s.to_string());
         }
 
-        self.last.clone().ok_or(ExecError::Other("No last input".to_string()))
+        self.last
+            .clone()
+            .ok_or(ExecError::Other("No last input".to_string()))
     }
 
-    fn is_assoc(&self) -> bool {true}
-    fn len(&mut self) -> usize { self.body.len() }
+    fn is_assoc(&self) -> bool {
+        true
+    }
+    fn len(&mut self) -> usize {
+        self.body.len()
+    }
 
     fn elem_len(&mut self, key: &str) -> Result<usize, ExecError> {
         if key == "@" || key == "*" {
             return Ok(self.len());
         }
 
-        let s = self.body.get(key).unwrap_or(&0).clone();
+        let s = *self.body.get(key).unwrap_or(&0);
 
         Ok(s.to_string().len())
     }
@@ -102,16 +110,18 @@ impl Data for IntAssocData {
         if self.body.is_empty() {
             return Ok(vec![]);
         }
-        
+
         let mut keys = self.keys();
         keys.sort();
         let mut ans = vec![];
         for i in keys {
             match self.body.get(&i) {
                 Some(s) => ans.push(s.to_string()),
-                None => if ! skip_none {
-                    ans.push("".to_string());
-                },
+                None => {
+                    if !skip_none {
+                        ans.push("".to_string());
+                    }
+                }
             }
         }
         Ok(ans)
@@ -128,7 +138,7 @@ impl Data for IntAssocData {
         }
 
         self.body.remove(key);
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -142,7 +152,7 @@ impl IntAssocData {
     pub fn set_elem(db_layer: &mut HashMap<String, Box<dyn Data>>, name: &str,
                      key: &String, val: &String) -> Result<(), ExecError> {
         match db_layer.get_mut(name) {
-            Some(v) => v.set_as_assoc(key, val), 
+            Some(v) => v.set_as_assoc(key, val),
             _ => Err(ExecError::Other("TODO".to_string())),
         }
     }
@@ -150,7 +160,7 @@ impl IntAssocData {
     pub fn append_elem(db_layer: &mut HashMap<String, Box<dyn Data>>, name: &str,
                      key: &String, val: &String) -> Result<(), ExecError> {
         match db_layer.get_mut(name) {
-            Some(v) => v.append_to_assoc_elem(key, val), 
+            Some(v) => v.append_to_assoc_elem(key, val),
             _ => Err(ExecError::Other("TODO".to_string())),
         }
     }*/

--- a/src/core/database/data/assoc_uninit.rs
+++ b/src/core/database/data/assoc_uninit.rs
@@ -1,26 +1,46 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
-use crate::error::exec::ExecError;
 use super::Data;
+use crate::error::exec::ExecError;
 
 #[derive(Debug, Clone, Default)]
-pub struct UninitAssoc { }
+pub struct UninitAssoc {}
 
 impl Data for UninitAssoc {
-    fn boxed_clone(&self) -> Box<dyn Data> { Box::new(self.clone()) }
-    fn print_body(&self) -> String {"".to_string()}
-
-    fn clear(&mut self) { }
-    fn is_initialized(&self) -> bool { false }
-    fn get_as_array(&mut self, _: &str, _: &str) -> Result<String, ExecError> {
-        Ok( "".to_string() )
+    fn boxed_clone(&self) -> Box<dyn Data> {
+        Box::new(self.clone())
     }
-    fn get_all_as_array(&mut self, _: bool) -> Result<Vec<String>, ExecError> { Ok(vec![]) }
-    fn get_all_indexes_as_array(&mut self) -> Result<Vec<String>, ExecError> { Ok(vec![]) }
-    fn get_as_single(&mut self) -> Result<String, ExecError> { Ok("".to_string()) }
-    fn is_assoc(&self) -> bool {true}
-    fn len(&mut self) -> usize { 0 }
-    fn elem_len(&mut self, _: &str) -> Result<usize, ExecError> { Ok(0) }
-    fn remove_elem(&mut self, _: &str) -> Result<(), ExecError> { Ok(()) }
+    fn print_body(&self) -> String {
+        "".to_string()
+    }
+
+    fn clear(&mut self) {}
+    fn is_initialized(&self) -> bool {
+        false
+    }
+    fn get_as_array(&mut self, _: &str, _: &str) -> Result<String, ExecError> {
+        Ok("".to_string())
+    }
+    fn get_all_as_array(&mut self, _: bool) -> Result<Vec<String>, ExecError> {
+        Ok(vec![])
+    }
+    fn get_all_indexes_as_array(&mut self) -> Result<Vec<String>, ExecError> {
+        Ok(vec![])
+    }
+    fn get_as_single(&mut self) -> Result<String, ExecError> {
+        Ok("".to_string())
+    }
+    fn is_assoc(&self) -> bool {
+        true
+    }
+    fn len(&mut self) -> usize {
+        0
+    }
+    fn elem_len(&mut self, _: &str) -> Result<usize, ExecError> {
+        Ok(0)
+    }
+    fn remove_elem(&mut self, _: &str) -> Result<(), ExecError> {
+        Ok(())
+    }
 }

--- a/src/core/database/data/epochrealtime.rs
+++ b/src/core/database/data/epochrealtime.rs
@@ -1,24 +1,36 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
+use super::Data;
 use crate::error::exec::ExecError;
 use crate::utils::clock;
-use super::Data;
 
 #[derive(Debug, Clone)]
-pub struct EpochRealTime { }
+pub struct EpochRealTime {}
 
 impl Data for EpochRealTime {
-    fn boxed_clone(&self) -> Box<dyn Data> { Box::new(self.clone()) }
-    fn print_body(&self) -> String { "".to_string() }
-
-    fn get_as_single(&mut self) -> Result<String, ExecError> {
-        Ok( clock::get_epochrealtime() )
+    fn boxed_clone(&self) -> Box<dyn Data> {
+        Box::new(self.clone())
+    }
+    fn print_body(&self) -> String {
+        "".to_string()
     }
 
-    fn len(&mut self) -> usize { self.get_as_single().unwrap_or_default().len() }
-    fn set_as_single(&mut self, _: &str) -> Result<(), ExecError> { Ok(()) }
+    fn get_as_single(&mut self) -> Result<String, ExecError> {
+        Ok(clock::get_epochrealtime())
+    }
 
-    fn is_special(&self) -> bool {true}
-    fn is_single_num(&self) -> bool { true }
+    fn len(&mut self) -> usize {
+        self.get_as_single().unwrap_or_default().len()
+    }
+    fn set_as_single(&mut self, _: &str) -> Result<(), ExecError> {
+        Ok(())
+    }
+
+    fn is_special(&self) -> bool {
+        true
+    }
+    fn is_single_num(&self) -> bool {
+        true
+    }
 }

--- a/src/core/database/data/epochseconds.rs
+++ b/src/core/database/data/epochseconds.rs
@@ -1,24 +1,36 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
+use super::Data;
 use crate::error::exec::ExecError;
 use crate::utils::clock;
-use super::Data;
 
 #[derive(Debug, Clone)]
-pub struct EpochSeconds { }
+pub struct EpochSeconds {}
 
 impl Data for EpochSeconds {
-    fn boxed_clone(&self) -> Box<dyn Data> { Box::new(self.clone()) }
-    fn print_body(&self) -> String { "".to_string() }
-
-    fn get_as_single(&mut self) -> Result<String, ExecError> {
-        Ok( clock::get_epochseconds() )
+    fn boxed_clone(&self) -> Box<dyn Data> {
+        Box::new(self.clone())
+    }
+    fn print_body(&self) -> String {
+        "".to_string()
     }
 
-    fn len(&mut self) -> usize { self.get_as_single().unwrap_or_default().len() }
-    fn set_as_single(&mut self, _: &str) -> Result<(), ExecError> { Ok(()) }
+    fn get_as_single(&mut self) -> Result<String, ExecError> {
+        Ok(clock::get_epochseconds())
+    }
 
-    fn is_special(&self) -> bool {true}
-    fn is_single_num(&self) -> bool { true }
+    fn len(&mut self) -> usize {
+        self.get_as_single().unwrap_or_default().len()
+    }
+    fn set_as_single(&mut self, _: &str) -> Result<(), ExecError> {
+        Ok(())
+    }
+
+    fn is_special(&self) -> bool {
+        true
+    }
+    fn is_single_num(&self) -> bool {
+        true
+    }
 }

--- a/src/core/database/data/random.rs
+++ b/src/core/database/data/random.rs
@@ -1,11 +1,11 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
+use super::Data;
 use crate::error::exec::ExecError;
-use rand_chacha::ChaCha20Rng;
 use rand_chacha::rand_core::RngCore;
 use rand_chacha::rand_core::SeedableRng;
-use super::Data;
+use rand_chacha::ChaCha20Rng;
 
 #[derive(Debug, Clone)]
 pub struct RandomVar {
@@ -18,7 +18,9 @@ impl Data for RandomVar {
         Box::new(self.clone())
     }
 
-    fn print_body(&self) -> String { self.prev.clone() }
+    fn print_body(&self) -> String {
+        self.prev.clone()
+    }
 
     fn get_as_single(&mut self) -> Result<String, ExecError> {
         let rand = self.rng.next_u32() & 0x7FFF;
@@ -31,12 +33,14 @@ impl Data for RandomVar {
     }
 
     fn set_as_single(&mut self, value: &str) -> Result<(), ExecError> {
-        let seed = u64::from_str_radix(&value, 10).unwrap_or(0);
+        let seed = value.parse::<u64>().unwrap_or(0);
         self.rng = ChaCha20Rng::seed_from_u64(seed + 4011); //4011: for bash test
         Ok(())
     }
 
-    fn is_special(&self) -> bool {true}
+    fn is_special(&self) -> bool {
+        true
+    }
 }
 
 impl RandomVar {

--- a/src/core/database/data/seconds.rs
+++ b/src/core/database/data/seconds.rs
@@ -1,10 +1,10 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
+use super::Data;
 use crate::error::exec::ExecError;
 use crate::utils::clock;
 use std::time::Duration;
-use super::Data;
 
 #[derive(Debug, Clone)]
 pub struct Seconds {
@@ -44,8 +44,12 @@ impl Data for Seconds {
         Ok(()) // TODO
     }
 
-    fn is_special(&self) -> bool {true}
-    fn is_single_num(&self) -> bool { true }
+    fn is_special(&self) -> bool {
+        true
+    }
+    fn is_single_num(&self) -> bool {
+        true
+    }
 }
 
 impl Seconds {

--- a/src/core/database/data/single.rs
+++ b/src/core/database/data/single.rs
@@ -1,9 +1,9 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
-use crate::utils;
-use crate::error::exec::ExecError;
 use super::Data;
+use crate::error::exec::ExecError;
+use crate::utils;
 
 #[derive(Debug, Clone)]
 pub struct SingleData {
@@ -12,17 +12,23 @@ pub struct SingleData {
 
 impl From<&str> for SingleData {
     fn from(s: &str) -> Self {
-        Self { body: s.to_string() }
+        Self {
+            body: s.to_string(),
+        }
     }
 }
 
 impl Data for SingleData {
-    fn boxed_clone(&self) -> Box<dyn Data> { Box::new(self.clone()) }
-    fn print_body(&self) -> String { 
+    fn boxed_clone(&self) -> Box<dyn Data> {
+        Box::new(self.clone())
+    }
+    fn print_body(&self) -> String {
         utils::to_ansi_c(&self.body.to_string())
     }
 
-    fn clear(&mut self) { self.body.clear(); }
+    fn clear(&mut self) {
+        self.body.clear();
+    }
 
     fn set_as_single(&mut self, value: &str) -> Result<(), ExecError> {
         self.body = value.to_string();
@@ -30,16 +36,22 @@ impl Data for SingleData {
     }
 
     fn append_as_single(&mut self, value: &str) -> Result<(), ExecError> {
-        self.body += &value;
+        self.body += value;
         Ok(())
     }
 
-    fn get_as_single(&mut self) -> Result<String, ExecError> { Ok(self.body.to_string()) }
-    fn len(&mut self) -> usize { self.body.chars().count() }
-    fn is_single(&self) -> bool {true}
+    fn get_as_single(&mut self) -> Result<String, ExecError> {
+        Ok(self.body.to_string())
+    }
+    fn len(&mut self) -> usize {
+        self.body.chars().count()
+    }
+    fn is_single(&self) -> bool {
+        true
+    }
 }
 
-    /*
+/*
 impl SingleData {
     pub fn set_new_entry(db_layer: &mut HashMap<String, Box<dyn Data>>, name: &str, value: &str)-> Result<(), ExecError> {
         db_layer.insert( name.to_string(), Box::new(SingleData::from(value)) );

--- a/src/core/database/data/single_int.rs
+++ b/src/core/database/data/single_int.rs
@@ -1,9 +1,9 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
-use crate::utils;
-use crate::error::exec::ExecError;
 use super::Data;
+use crate::error::exec::ExecError;
+use crate::utils;
 
 #[derive(Debug, Clone)]
 pub struct IntData {
@@ -11,19 +11,21 @@ pub struct IntData {
 }
 
 impl Data for IntData {
-    fn boxed_clone(&self) -> Box<dyn Data> { Box::new(self.clone()) }
-    fn print_body(&self) -> String { 
+    fn boxed_clone(&self) -> Box<dyn Data> {
+        Box::new(self.clone())
+    }
+    fn print_body(&self) -> String {
         utils::to_ansi_c(&self.body.to_string())
     }
 
-    fn clear(&mut self) { }
+    fn clear(&mut self) {}
 
     fn set_as_single(&mut self, value: &str) -> Result<(), ExecError> {
         match value.parse::<isize>() {
             Ok(n) => self.body = n,
             Err(e) => {
                 return Err(ExecError::Other(e.to_string()));
-            },
+            }
         }
         Ok(())
     }
@@ -33,7 +35,7 @@ impl Data for IntData {
             Ok(n) => self.body += n,
             Err(e) => {
                 return Err(ExecError::Other(e.to_string()));
-            },
+            }
         }
         Ok(())
     }
@@ -43,10 +45,20 @@ impl Data for IntData {
         Ok(())
     }
 
-    fn get_as_single(&mut self) -> Result<String, ExecError> { Ok(self.body.to_string()) }
-    fn get_as_single_num(&mut self) -> Result<isize, ExecError> { Ok(self.body) }
+    fn get_as_single(&mut self) -> Result<String, ExecError> {
+        Ok(self.body.to_string())
+    }
+    fn get_as_single_num(&mut self) -> Result<isize, ExecError> {
+        Ok(self.body)
+    }
 
-    fn len(&mut self) -> usize { self.body.to_string().len() }
-    fn is_single(&self) -> bool {true}
-    fn is_single_num(&self) -> bool {true}
+    fn len(&mut self) -> usize {
+        self.body.to_string().len()
+    }
+    fn is_single(&self) -> bool {
+        true
+    }
+    fn is_single_num(&self) -> bool {
+        true
+    }
 }

--- a/src/core/database/data/srandom.rs
+++ b/src/core/database/data/srandom.rs
@@ -1,10 +1,10 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
-use crate::error::exec::ExecError;
-use rand_chacha::ChaCha20Rng;
-use rand_chacha::rand_core::{RngCore, SeedableRng};
 use super::Data;
+use crate::error::exec::ExecError;
+use rand_chacha::rand_core::{RngCore, SeedableRng};
+use rand_chacha::ChaCha20Rng;
 
 #[derive(Debug, Clone)]
 pub struct SRandomVar {
@@ -17,7 +17,9 @@ impl Data for SRandomVar {
         Box::new(self.clone())
     }
 
-    fn print_body(&self) -> String { self.prev.clone() }
+    fn print_body(&self) -> String {
+        self.prev.clone()
+    }
 
     fn get_as_single(&mut self) -> Result<String, ExecError> {
         let rand = self.rng.next_u32();
@@ -29,9 +31,13 @@ impl Data for SRandomVar {
         self.prev.len()
     }
 
-    fn set_as_single(&mut self, _: &str) -> Result<(), ExecError> { Ok(()) }
+    fn set_as_single(&mut self, _: &str) -> Result<(), ExecError> {
+        Ok(())
+    }
 
-    fn is_special(&self) -> bool {true}
+    fn is_special(&self) -> bool {
+        true
+    }
 }
 
 impl SRandomVar {

--- a/src/core/database/database_checker.rs
+++ b/src/core/database/database_checker.rs
@@ -1,15 +1,15 @@
 //SPDXFileCopyrightText: 2025 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
+use crate::core::DataBase;
+use crate::error::exec::ExecError;
 use crate::utils;
 use crate::utils::file_check;
-use crate::error::exec::ExecError;
-use crate::core::DataBase;
 
 impl DataBase {
     pub fn has_array_value(&mut self, name: &str, index: &str) -> bool {
         let num = self.params.len();
-        for layer in (0..num).rev()  {
+        for layer in (0..num).rev() {
             if let Some(e) = self.params[layer].get(name) {
                 let mut a = e.clone();
                 return a.get_as_array_or_assoc(index, "").is_ok();
@@ -33,8 +33,8 @@ impl DataBase {
         }
 
         let num = self.params.len();
-        for layer in (0..num).rev()  {
-            if self.params[layer].get(name).is_some() {
+        for layer in (0..num).rev() {
+            if self.params[layer].contains_key(name) {
                 return true;
             }
         }
@@ -42,7 +42,7 @@ impl DataBase {
     }
 
     pub fn name_check(name: &str) -> Result<(), ExecError> {
-        if ! utils::is_param(name) {
+        if !utils::is_param(name) {
             return Err(ExecError::VariableInvalid(name.to_string()));
         }
         Ok(())
@@ -59,7 +59,7 @@ impl DataBase {
                 return Err(ExecError::Other(msg));
             }
 
-            if file_check::is_executable(&c) {
+            if file_check::is_executable(c) {
                 let msg = format!("{}: not found", &c);
                 return Err(ExecError::Other(msg));
             }
@@ -90,21 +90,21 @@ impl DataBase {
 
     pub fn is_single(&mut self, name: &str) -> bool {
         match self.get_ref(name) {
-            Some(d) => return d.is_single(),
+            Some(d) => d.is_single(),
             _ => false,
         }
     }
 
     pub fn is_single_num(&mut self, name: &str) -> bool {
         match self.get_ref(name) {
-            Some(d) => return d.is_single_num(),
+            Some(d) => d.is_single_num(),
             _ => false,
         }
     }
 
     pub fn is_array(&mut self, name: &str) -> bool {
         match self.get_ref(name) {
-            Some(d) => return d.is_array(),
+            Some(d) => d.is_array(),
             _ => false,
         }
     }

--- a/src/core/database/database_getter.rs
+++ b/src/core/database/database_getter.rs
@@ -1,11 +1,11 @@
 //SPDXFileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDXLicense-Identifier: BSD-3-Clause
 
-use crate::error::exec::ExecError;
-use std::env;
-use std::collections::HashSet;
-use super::DataBase;
 use super::data::Data;
+use super::DataBase;
+use crate::error::exec::ExecError;
+use std::collections::HashSet;
+use std::env;
 
 impl DataBase {
     pub fn get_ref(&mut self, name: &str) -> Option<&mut Box<dyn Data>> {
@@ -21,17 +21,21 @@ impl DataBase {
     pub fn get_ifs_head(&mut self) -> String {
         let ifs = self.get_param("IFS").unwrap_or(" ".to_string());
         match ifs.as_str() {
-            "" => "".to_string(), 
+            "" => "".to_string(),
             s => s.chars().next().unwrap().to_string(),
         }
     }
 
-    pub fn get_layer_num(&mut self) -> usize { self.params.len() }
+    pub fn get_layer_num(&mut self) -> usize {
+        self.params.len()
+    }
 
     pub fn get_keys(&mut self) -> Vec<String> {
         let mut keys = HashSet::new();
         for layer in &self.params {
-            layer.keys().for_each(|k| {keys.insert(k);} );
+            layer.keys().for_each(|k| {
+                keys.insert(k);
+            });
         }
         for f in &self.functions {
             keys.insert(f.0);
@@ -43,18 +47,15 @@ impl DataBase {
 
     pub fn get_layer_pos(&mut self, name: &str) -> Option<usize> {
         let num = self.params.len();
-        for layer in (0..num).rev()  {
-            if self.params[layer].get(name).is_some() {
-                return Some(layer);
-            }
-        }
-        None
+        (0..num)
+            .rev()
+            .find(|&layer| self.params[layer].contains_key(name))
     }
 
     pub fn get_position_params(&self) -> Vec<String> {
         match self.position_parameters.last() {
             Some(v) => v[1..].to_vec(),
-            _       => vec![],
+            _ => vec![],
         }
     }
 
@@ -64,19 +65,17 @@ impl DataBase {
             return self.position_parameters[layer].clone();
         }
 
-        match self.get_ref(name) {
-            Some(d) => {
-                match d.get_all_indexes_as_array() {
-                    Ok(v) => v,
-                    _ => vec![],
-                }
-            },
-            None => vec![],
-        }
+        self.get_ref(name)
+            .map(|d| d.get_all_indexes_as_array().unwrap_or_default())
+            .unwrap_or_default()
     }
 
-    pub fn get_vec_from(&mut self, name: &str, pos: usize, flatten: bool)
-    -> Result<Vec<String>, ExecError> {
+    pub fn get_vec_from(
+        &mut self,
+        name: &str,
+        pos: usize,
+        flatten: bool,
+    ) -> Result<Vec<String>, ExecError> {
         let layer = self.position_parameters.len() - 1;
         if name == "@" {
             return Ok(self.position_parameters[layer].clone());
@@ -88,13 +87,13 @@ impl DataBase {
                     return Ok(v);
                 }
                 Ok(vec![])
-            },
+            }
             None => {
                 if self.flags.contains('u') {
                     return Err(ExecError::UnboundVariable(name.to_string()));
                 }
                 Ok(vec![])
-            },
+            }
         }
     }
 
@@ -112,8 +111,7 @@ impl DataBase {
         0
     }
 
-    pub fn get_vec(&mut self, name: &str, flatten: bool)
-    -> Result<Vec<String>, ExecError> {
+    pub fn get_vec(&mut self, name: &str, flatten: bool) -> Result<Vec<String>, ExecError> {
         self.get_vec_from(name, 0, flatten)
     }
 
@@ -130,14 +128,16 @@ impl DataBase {
         }
 
         let ifs = self.get_ifs_head();
-        self.params[layer.unwrap()].get_mut(name)
-            .unwrap().get_as_array_or_assoc(pos, &ifs)
+        self.params[layer.unwrap()]
+            .get_mut(name)
+            .unwrap()
+            .get_as_array_or_assoc(pos, &ifs)
     }
 
-    pub fn get_elem_or_param(&mut self, name: &str, index: &String) -> Result<String, ExecError> {
+    pub fn get_elem_or_param(&mut self, name: &str, index: &str) -> Result<String, ExecError> {
         match index.is_empty() {
-            true  => self.get_param(&name),
-            false => self.get_elem(&name, &index),
+            true => self.get_param(name),
+            false => self.get_elem(name, index),
         }
     }
 
@@ -160,7 +160,7 @@ impl DataBase {
 
         if name == "@" || name == "*" {
             let layer = self.position_parameters.len();
-            return Ok(self.position_parameters[layer-1].len() - 1);
+            return Ok(self.position_parameters[layer - 1].len() - 1);
         }
 
         if let Ok(n) = name.parse::<usize>() {
@@ -189,7 +189,8 @@ impl DataBase {
             return Ok(val);
         }
 
-        if name == "@" || name == "*" { //return connected position params
+        if name == "@" || name == "*" {
+            //return connected position params
             return connected_position_params(self, name == "*");
         } //in double quoted subword, this method should not be used
 
@@ -199,11 +200,11 @@ impl DataBase {
 
         if let Some(v) = self.get_ref(name) {
             if v.is_special() {
-                return Ok(v.get_as_single()?);
-            }else if v.is_single_num() {
-                let val = v.get_as_single_num()?;//.unwrap_or_default();
+                return v.get_as_single();
+            } else if v.is_single_num() {
+                let val = v.get_as_single_num()?; //.unwrap_or_default();
                 return Ok(val.to_string());
-            }else{
+            } else {
                 let val = v.get_as_single().unwrap_or_default();
                 return Ok(val);
             }
@@ -222,7 +223,7 @@ impl DataBase {
     }
 }
 
-pub fn special_param(db :&DataBase, name: &str) -> Option<String> {
+pub fn special_param(db: &DataBase, name: &str) -> Option<String> {
     let val = match name {
         "-" => db.flags.clone(),
         "?" => db.exit_status.to_string(),
@@ -230,14 +231,14 @@ pub fn special_param(db :&DataBase, name: &str) -> Option<String> {
         "#" => {
             let pos = db.position_parameters.len() - 1;
             (db.position_parameters[pos].len() - 1).to_string()
-        },
+        }
         _ => return None,
     };
 
     Some(val)
 }
 
-pub fn connected_position_params(db :&mut DataBase, aster: bool) -> Result<String, ExecError> {
+pub fn connected_position_params(db: &mut DataBase, aster: bool) -> Result<String, ExecError> {
     let mut joint = " ".to_string();
     if aster {
         joint = db.get_ifs_head();
@@ -245,16 +246,16 @@ pub fn connected_position_params(db :&mut DataBase, aster: bool) -> Result<Strin
 
     match db.position_parameters.last() {
         Some(a) => Ok(a[1..].join(&joint)),
-        _       => Ok("".to_string()),
+        _ => Ok("".to_string()),
     }
 }
 
 pub fn position_param(db: &DataBase, pos: usize) -> Result<String, ExecError> {
     let layer = db.position_parameters.len();
-    return match db.position_parameters[layer-1].len() > pos {
-        true  => Ok(db.position_parameters[layer-1][pos].to_string()),
+    match db.position_parameters[layer - 1].len() > pos {
+        true => Ok(db.position_parameters[layer - 1][pos].to_string()),
         false => Ok(String::new()),
-    };
+    }
 }
 
 /*

--- a/src/core/database/database_setter.rs
+++ b/src/core/database/database_setter.rs
@@ -3,19 +3,27 @@
 
 //The methods of DataBase are distributed in database/database_*.rs files.
 
+use super::data::epochrealtime::EpochRealTime;
+use super::data::epochseconds::EpochSeconds;
+use super::data::random::RandomVar;
+use super::data::seconds::Seconds;
+use super::data::srandom::SRandomVar;
+use super::{
+    ArrayData, AssocData, Data, IntArrayData, IntAssocData, IntData, SingleData, UninitArray,
+    UninitAssoc,
+};
 use crate::core::DataBase;
 use crate::error::exec::ExecError;
-use super::{ArrayData, AssocData, SingleData, IntData, IntArrayData, IntAssocData, Data, UninitArray, UninitAssoc};
 use nix::unistd;
-use super::data::random::RandomVar;
-use super::data::srandom::SRandomVar;
-use super::data::seconds::Seconds;
-use super::data::epochseconds::EpochSeconds;
-use super::data::epochrealtime::EpochRealTime;
 use std::{env, process};
 
 impl DataBase {
-    pub fn init_as_num(&mut self, name: &str, value: &str, layer: Option<usize>) -> Result<(), ExecError> {
+    pub fn init_as_num(
+        &mut self,
+        name: &str,
+        value: &str,
+        layer: Option<usize>,
+    ) -> Result<(), ExecError> {
         Self::name_check(name)?;
         self.write_check(name)?;
         if self.flags.contains('r') {
@@ -28,27 +36,33 @@ impl DataBase {
         let layer = self.get_target_layer(name, layer);
         match self.param_options[layer].get_mut(name) {
             Some(e) => *e += "i",
-            None => {self.param_options[layer].insert(name.to_string(), "i".to_string());},
+            None => {
+                self.param_options[layer].insert(name.to_string(), "i".to_string());
+            }
         }
         let db_layer = &mut self.params[layer];
 
-        let mut data = IntData{body: 0};
+        let mut data = IntData { body: 0 };
 
-        if value != "" {
+        if !value.is_empty() {
             match value.parse::<isize>() {
                 Ok(n) => data.body = n,
                 Err(e) => {
                     return Err(ExecError::Other(e.to_string()));
-                },
+                }
             }
         }
 
-        db_layer.insert( name.to_string(), Box::new(data) );
+        db_layer.insert(name.to_string(), Box::new(data));
         Ok(())
     }
 
-    pub fn set_param(&mut self, name: &str, val: &str, layer: Option<usize>)
-    -> Result<(), ExecError> {
+    pub fn set_param(
+        &mut self,
+        name: &str,
+        val: &str,
+        layer: Option<usize>,
+    ) -> Result<(), ExecError> {
         Self::name_check(name)?;
         self.write_check(name)?;
         if self.flags.contains('r') {
@@ -63,8 +77,7 @@ impl DataBase {
             self.position_parameters[n][0] = val.to_string();
         }
 
-        if ! self.flags.contains('r')
-        && ( self.flags.contains('a') || self.has_flag(name, 'x') ) {
+        if !self.flags.contains('r') && (self.flags.contains('a') || self.has_flag(name, 'x')) {
             env::set_var(name, "");
         }
 
@@ -76,23 +89,27 @@ impl DataBase {
         }
 
         if db_layer.get(name).is_none() {
-            db_layer.insert( name.to_string(), Box::new(SingleData::from("")) );
+            db_layer.insert(name.to_string(), Box::new(SingleData::from("")));
         }
 
         let d = db_layer.get_mut(name).unwrap();
 
         if d.is_array() {
-            if ! d.is_initialized() {
+            if !d.is_initialized() {
                 *d = ArrayData::default().boxed_clone();
             }
             return d.set_as_array("0", val);
         }
-     
+
         d.set_as_single(val)
     }
 
-    pub fn append_param(&mut self, name: &str, val: &str, layer: Option<usize>)
-    -> Result<(), ExecError> {
+    pub fn append_param(
+        &mut self,
+        name: &str,
+        val: &str,
+        layer: Option<usize>,
+    ) -> Result<(), ExecError> {
         Self::name_check(name)?;
         self.write_check(name)?;
         if self.flags.contains('r') {
@@ -107,10 +124,10 @@ impl DataBase {
             self.position_parameters[n][0] += val;
         }
 
-
-        if ! self.flags.contains('r')
-        && ( self.flags.contains('a') || self.has_flag(name, 'x') )
-        && ! env::var(name).is_ok() {
+        if !self.flags.contains('r')
+            && (self.flags.contains('a') || self.has_flag(name, 'x'))
+            && env::var(name).is_err()
+        {
             env::set_var(name, "");
         }
 
@@ -121,7 +138,7 @@ impl DataBase {
         }
 
         if db_layer.get(name).is_none() {
-            db_layer.insert( name.to_string(), Box::new(SingleData::from("")) );
+            db_layer.insert(name.to_string(), Box::new(SingleData::from("")));
         }
 
         let d = db_layer.get_mut(name).unwrap();
@@ -129,54 +146,77 @@ impl DataBase {
         if d.is_array() {
             return d.append_to_array_elem("0", val);
         }
-     
+
         d.append_as_single(val)
     }
 
-    pub fn set_param2(&mut self, name: &str, index: &String, val: &String,
-                      layer: Option<usize>) -> Result<(), ExecError> {
+    pub fn set_param2(
+        &mut self,
+        name: &str,
+        index: &str,
+        val: &str,
+        layer: Option<usize>,
+    ) -> Result<(), ExecError> {
         if index.is_empty() {
             return self.set_param(name, val, layer);
         }
 
         if self.is_array(name) {
             if let Ok(n) = index.parse::<usize>() {
-                self.set_array_elem(&name, val, n, layer)?;
+                self.set_array_elem(name, val, n, layer)?;
             }
-        }else if self.is_assoc(name) {
-            self.set_assoc_elem(&name, &index, val, layer)?;
-        }else{
+        } else if self.is_assoc(name) {
+            self.set_assoc_elem(name, index, val, layer)?;
+        } else {
             match index.parse::<usize>() {
-                Ok(n) => {self.set_array_elem(&name, val, n, layer)?;},
-                _ => {self.set_assoc_elem(&name, &index, val, layer)?;},
+                Ok(n) => {
+                    self.set_array_elem(name, val, n, layer)?;
+                }
+                _ => {
+                    self.set_assoc_elem(name, index, val, layer)?;
+                }
             }
         }
         Ok(())
     }
 
-    pub fn append_param2(&mut self, name: &str, index: &String, val: &String,
-                      layer: Option<usize>) -> Result<(), ExecError> {
+    pub fn append_param2(
+        &mut self,
+        name: &str,
+        index: &str,
+        val: &str,
+        layer: Option<usize>,
+    ) -> Result<(), ExecError> {
         if index.is_empty() {
             return self.append_param(name, val, layer);
         }
 
         if self.is_array(name) {
             if let Ok(n) = index.parse::<usize>() {
-                self.append_to_array_elem(&name, val, n, layer)?;
+                self.append_to_array_elem(name, val, n, layer)?;
             }
-        }else if self.is_assoc(name) {
-            self.append_to_assoc_elem(&name, &index, val, layer)?;
-        }else{
+        } else if self.is_assoc(name) {
+            self.append_to_assoc_elem(name, index, val, layer)?;
+        } else {
             match index.parse::<usize>() {
-                Ok(n) => {self.append_to_array_elem(&name, val, n, layer)?;},
-                _ => {self.append_to_assoc_elem(&name, &index, val, layer)?;},
+                Ok(n) => {
+                    self.append_to_array_elem(name, val, n, layer)?;
+                }
+                _ => {
+                    self.append_to_assoc_elem(name, index, val, layer)?;
+                }
             }
         }
         Ok(())
     }
 
-    pub fn set_array_elem(&mut self, name: &str, val: &String, pos: usize, layer: Option<usize>)
-    -> Result<(), ExecError> {
+    pub fn set_array_elem(
+        &mut self,
+        name: &str,
+        val: &str,
+        pos: usize,
+        layer: Option<usize>,
+    ) -> Result<(), ExecError> {
         Self::name_check(name)?;
         self.write_check(name)?;
         if self.flags.contains('r') {
@@ -190,8 +230,13 @@ impl DataBase {
         ArrayData::set_elem(&mut self.params[layer], name, pos, val)
     }
 
-    pub fn append_to_array_elem(&mut self, name: &str, val: &String,
-            pos: usize, layer: Option<usize>) -> Result<(), ExecError> {
+    pub fn append_to_array_elem(
+        &mut self,
+        name: &str,
+        val: &str,
+        pos: usize,
+        layer: Option<usize>,
+    ) -> Result<(), ExecError> {
         Self::name_check(name)?;
         self.write_check(name)?;
         if self.flags.contains('r') {
@@ -205,8 +250,13 @@ impl DataBase {
         ArrayData::append_elem(&mut self.params[layer], name, pos, val)
     }
 
-    pub fn set_assoc_elem(&mut self, name: &str, key: &String,
-            val: &String, layer: Option<usize>) -> Result<(), ExecError> {
+    pub fn set_assoc_elem(
+        &mut self,
+        name: &str,
+        key: &str,
+        val: &str,
+        layer: Option<usize>,
+    ) -> Result<(), ExecError> {
         Self::name_check(name)?;
         self.write_check(name)?;
         if self.flags.contains('r') {
@@ -223,20 +273,26 @@ impl DataBase {
 
         match db_layer.get_mut(name) {
             Some(v) => {
-                if ! v.is_initialized() {
+                if !v.is_initialized() {
                     *v = match i_flag {
-                        true  => IntAssocData::default().boxed_clone(),
+                        true => IntAssocData::default().boxed_clone(),
                         false => AssocData::default().boxed_clone(),
                     };
                 }
 
                 v.set_as_assoc(key, val)
-            }, 
+            }
             _ => Err(ExecError::Other("TODO".to_string())),
         }
     }
 
-    pub fn append_to_assoc_elem(&mut self, name: &str, key: &String, val: &String, layer: Option<usize>) -> Result<(), ExecError> {
+    pub fn append_to_assoc_elem(
+        &mut self,
+        name: &str,
+        key: &str,
+        val: &str,
+        layer: Option<usize>,
+    ) -> Result<(), ExecError> {
         Self::name_check(name)?;
         self.write_check(name)?;
         if self.flags.contains('r') {
@@ -250,16 +306,18 @@ impl DataBase {
         AssocData::append_elem(&mut self.params[layer], name, key, val)
     }
 
-    pub fn set_array(&mut self, name: &str, v: Option<Vec<String>>,
-                     layer: Option<usize>) -> Result<(), ExecError> {
+    pub fn set_array(
+        &mut self,
+        name: &str,
+        v: Option<Vec<String>>,
+        layer: Option<usize>,
+    ) -> Result<(), ExecError> {
         Self::name_check(name)?;
         self.write_check(name)?;
         if self.flags.contains('r') {
-            if name == "BASH_CMDS" {
-                if v.is_some() {
-                    for val in v.as_ref().unwrap() {
-                        self.rsh_cmd_check(&vec![val.to_string()])?;
-                    }
+            if name == "BASH_CMDS" && v.is_some() {
+                for val in v.as_ref().unwrap() {
+                    self.rsh_cmd_check(&vec![val.to_string()])?;
                 }
             }
             self.rsh_check(name)?;
@@ -269,23 +327,25 @@ impl DataBase {
         let db_layer = &mut self.params[layer];
 
         if v.is_none() {
-            db_layer.insert(name.to_string(), UninitArray{}.boxed_clone());
-        }else {
+            db_layer.insert(name.to_string(), UninitArray {}.boxed_clone());
+        } else {
             db_layer.insert(name.to_string(), Box::new(ArrayData::from(v)));
         }
         Ok(())
     }
 
-    pub fn set_int_array(&mut self, name: &str, v: Option<Vec<String>>,
-                     layer: Option<usize>) -> Result<(), ExecError> {
+    pub fn set_int_array(
+        &mut self,
+        name: &str,
+        v: Option<Vec<String>>,
+        layer: Option<usize>,
+    ) -> Result<(), ExecError> {
         Self::name_check(name)?;
         self.write_check(name)?;
         if self.flags.contains('r') {
-            if name == "BASH_CMDS" {
-                if v.is_some() {
-                    for val in v.as_ref().unwrap() {
-                        self.rsh_cmd_check(&vec![val.to_string()])?;
-                    }
+            if name == "BASH_CMDS" && v.is_some() {
+                for val in v.as_ref().unwrap() {
+                    self.rsh_cmd_check(&vec![val.to_string()])?;
                 }
             }
             self.rsh_check(name)?;
@@ -295,15 +355,17 @@ impl DataBase {
 
         match self.param_options[layer].get_mut(name) {
             Some(e) => *e += "i",
-            None => {self.param_options[layer].insert(name.to_string(), "i".to_string());},
+            None => {
+                self.param_options[layer].insert(name.to_string(), "i".to_string());
+            }
         }
 
         let db_layer = &mut self.params[layer];
         db_layer.insert(name.to_string(), IntArrayData::default().boxed_clone());
-        
+
         if v.is_some() {
             for (i, e) in v.unwrap().into_iter().enumerate() {
-                self.set_array_elem(&name, &e, i, Some(layer))?;
+                self.set_array_elem(name, &e, i, Some(layer))?;
             }
         }
 
@@ -320,7 +382,7 @@ impl DataBase {
         let layer = self.get_target_layer(name, layer);
         let db_layer = &mut self.params[layer];
 
-        db_layer.insert(name.to_string(), UninitAssoc{}.boxed_clone());
+        db_layer.insert(name.to_string(), UninitAssoc {}.boxed_clone());
         Ok(())
     }
 }
@@ -336,17 +398,17 @@ pub fn initialize(db: &mut DataBase) -> Result<(), String> {
     db.set_param("IFS", " \t\n", None)?;
 
     db.init_as_num("UID", &unistd::getuid().to_string(), None)?;
-    db.param_options[0].insert( "UID".to_string(), "ir".to_string());
+    db.param_options[0].insert("UID".to_string(), "ir".to_string());
 
-    db.params[0].insert( "RANDOM".to_string(), Box::new(RandomVar::new()) );
-    db.param_options[0].insert( "RANDOM".to_string(), "i".to_string());
+    db.params[0].insert("RANDOM".to_string(), Box::new(RandomVar::new()));
+    db.param_options[0].insert("RANDOM".to_string(), "i".to_string());
 
-    db.params[0].insert( "SRANDOM".to_string(), Box::new(SRandomVar::new()) );
-    db.param_options[0].insert( "SRANDOM".to_string(), "i".to_string());
+    db.params[0].insert("SRANDOM".to_string(), Box::new(SRandomVar::new()));
+    db.param_options[0].insert("SRANDOM".to_string(), "i".to_string());
 
-    db.params[0].insert( "SECONDS".to_string(), Box::new(Seconds::new()) );
-    db.params[0].insert( "EPOCHSECONDS".to_string(), Box::new(EpochSeconds{} ) );
-    db.params[0].insert( "EPOCHREALTIME".to_string(), Box::new(EpochRealTime{} ) );
+    db.params[0].insert("SECONDS".to_string(), Box::new(Seconds::new()));
+    db.params[0].insert("EPOCHSECONDS".to_string(), Box::new(EpochSeconds {}));
+    db.params[0].insert("EPOCHREALTIME".to_string(), Box::new(EpochRealTime {}));
 
     db.set_array("FUNCNAME", None, None)?;
     db.set_array("BASH_SOURCE", Some(vec![]), None)?;
@@ -363,6 +425,8 @@ pub fn flag(db: &mut DataBase, name: &str, flag: char) {
     let rf = &mut db.param_options[layer];
     match rf.get_mut(name) {
         Some(d) => d.push(flag),
-        None => {rf.insert(name.to_string(), flag.to_string()); },
+        None => {
+            rf.insert(name.to_string(), flag.to_string());
+        }
     }
 }

--- a/src/core/options.rs
+++ b/src/core/options.rs
@@ -25,17 +25,50 @@ impl Options {
 
     pub fn new_as_shopts() -> Options {
         let mut options = Options::default();
-        let opt_strs = vec!["autocd", "cdable_vars", "cdspell", "checkhash",
-                   "checkjobs", "checkwinsize", "cmdhist", "compat31",
-                   "compat32", "compat40", "compat41", "dirspell",
-                   "dotglob", "execfail", "expand_aliases", "extdebug",
-                   "extglob", "extquote", "failglob", "force_fignore",
-                   "globstar", "globskipdots", "gnu_errfmt", "histappend", "histreedit",
-                   "histverify", "hostcomplete", "huponexit", "interactive_comments",
-                   "lastpipe", "lithist", "login_shell", "mailwarn",
-                   "no_empty_cmd_completion", "nocaseglob", "nocasematch", "nullglob",
-                   "promptvars", "restricted_shell", "shift_verbose",
-                   "sourcepath", "xpg_echo"];
+        let opt_strs = vec![
+            "autocd",
+            "cdable_vars",
+            "cdspell",
+            "checkhash",
+            "checkjobs",
+            "checkwinsize",
+            "cmdhist",
+            "compat31",
+            "compat32",
+            "compat40",
+            "compat41",
+            "dirspell",
+            "dotglob",
+            "execfail",
+            "expand_aliases",
+            "extdebug",
+            "extglob",
+            "extquote",
+            "failglob",
+            "force_fignore",
+            "globstar",
+            "globskipdots",
+            "gnu_errfmt",
+            "histappend",
+            "histreedit",
+            "histverify",
+            "hostcomplete",
+            "huponexit",
+            "interactive_comments",
+            "lastpipe",
+            "lithist",
+            "login_shell",
+            "mailwarn",
+            "no_empty_cmd_completion",
+            "nocaseglob",
+            "nocasematch",
+            "nullglob",
+            "promptvars",
+            "restricted_shell",
+            "shift_verbose",
+            "sourcepath",
+            "xpg_echo",
+        ];
 
         for opt in opt_strs {
             options.opts.insert(opt.to_string(), false);
@@ -46,10 +79,22 @@ impl Options {
             options.opts.insert(opt.to_string(), true);
         }
 
-        options.implemented = ["extglob", "progcomp", "nullglob", "dotglob", "globstar",
-                               "globskipdots", "nocasematch", "expand_aliases", "xpg_echo",
-                               "lastpipe", "execfail"]
-                                   .iter().map(|s| s.to_string()).collect();
+        options.implemented = [
+            "extglob",
+            "progcomp",
+            "nullglob",
+            "dotglob",
+            "globstar",
+            "globskipdots",
+            "nocasematch",
+            "expand_aliases",
+            "xpg_echo",
+            "lastpipe",
+            "execfail",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
         //TODO: nocasematch and xpg_echo are dummy
 
         options
@@ -57,38 +102,38 @@ impl Options {
 
     pub fn format(opt: &str, onoff: bool) -> String {
         let onoff_str = match onoff {
-            true  => "on",
+            true => "on",
             false => "off",
         };
 
         match opt.len() < 16 {
-            true  => format!("{:16}{}", opt, onoff_str),
-            false => format!("{}\t{}", opt, onoff_str), 
+            true => format!("{opt:16}{onoff_str}"),
+            false => format!("{opt}\t{onoff_str}"),
         }
     }
 
     pub fn format2(opt: &str, onoff: bool) -> String {
         let onoff_str = match onoff {
-            true  => "-",
+            true => "-",
             false => "+",
         };
 
-        format!("set {}o {}", onoff_str, opt)
+        format!("set {onoff_str}o {opt}")
     }
 
     pub fn print_opt(&self, opt: &str, set_format: bool) -> bool {
         match self.opts.get_key_value(opt) {
-            None     => {
-                eprintln!("sush: shopt: {}: invalid shell option name", opt);
+            None => {
+                eprintln!("sush: shopt: {opt}: invalid shell option name");
                 false
-            },
+            }
             Some(kv) => {
                 match set_format {
                     false => println!("{}", Self::format(kv.0, *kv.1)),
-                    true  => println!("{}", Self::format2(kv.0, *kv.1)),
+                    true => println!("{}", Self::format2(kv.0, *kv.1)),
                 }
                 true
-            },
+            }
         }
     }
 
@@ -98,22 +143,26 @@ impl Options {
             false => Self::format2,
         };
 
-        let mut list = self.opts.iter()
-                       .map(|opt| f(opt.0, *opt.1))
-                       .collect::<Vec<String>>();
+        let mut list = self
+            .opts
+            .iter()
+            .map(|opt| f(opt.0, *opt.1))
+            .collect::<Vec<String>>();
 
         list.sort();
-        list.iter().for_each(|e| println!("{}", e));
+        list.iter().for_each(|e| println!("{e}"));
     }
 
     pub fn print_if(&self, onoff: bool) {
-        let mut list = self.opts.iter()
-                       .filter(|opt| *opt.1 == onoff)
-                       .map(|opt| Self::format(opt.0, *opt.1))
-                       .collect::<Vec<String>>();
+        let mut list = self
+            .opts
+            .iter()
+            .filter(|opt| *opt.1 == onoff)
+            .map(|opt| Self::format(opt.0, *opt.1))
+            .collect::<Vec<String>>();
 
         list.sort();
-        list.iter().for_each(|e| println!("{}", e));
+        list.iter().for_each(|e| println!("{e}"));
     }
 
     pub fn exist(&self, opt: &str) -> bool {
@@ -125,8 +174,8 @@ impl Options {
     }
 
     pub fn set(&mut self, opt: &str, onoff: bool) -> Result<(), ExecError> {
-        if ! self.opts.contains_key(opt) {
-            let msg = format!("{}: invalid option name", opt);
+        if !self.opts.contains_key(opt) {
+            let msg = format!("{opt}: invalid option name");
             return Err(ExecError::Other(msg));
         }
 

--- a/src/elements.rs
+++ b/src/elements.rs
@@ -1,14 +1,14 @@
 //SPDX-FileCopyrightText: 2022 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-pub mod script;
+pub mod command;
+pub mod expr;
+pub mod io;
 pub mod job;
 pub mod pipeline;
-pub mod command;
-pub mod io;
-pub mod word;
+pub mod script;
 pub mod substitution;
 pub mod subword;
-pub mod expr;
+pub mod word;
 
 use self::io::pipe::Pipe;

--- a/src/elements/command.rs
+++ b/src/elements/command.rs
@@ -2,38 +2,38 @@
 //SPDX-License-Identifier: BSD-3-Clause
 
 pub mod arithmetic;
+pub mod brace;
 pub mod case;
-pub mod simple;
+pub mod r#for;
+pub mod function_def;
+pub mod r#if;
 pub mod paren;
 pub mod repeat;
-pub mod brace;
-pub mod r#for;
+pub mod simple;
 pub mod test;
-pub mod function_def;
 pub mod r#while;
-pub mod r#if;
 
-use crate::{proc_ctrl, ShellCore, Feeder, Script};
+use self::arithmetic::ArithmeticCommand;
+use self::brace::BraceCommand;
+use self::case::CaseCommand;
+use self::function_def::FunctionDefinition;
+use self::paren::ParenCommand;
+use self::r#for::ForCommand;
+use self::r#if::IfCommand;
+use self::r#while::WhileCommand;
+use self::repeat::RepeatCommand;
+use self::simple::SimpleCommand;
+use self::test::TestCommand;
+use super::io::redirect::Redirect;
+use super::{io, Pipe};
 use crate::error::exec::ExecError;
 use crate::error::parse::ParseError;
 use crate::utils::exit;
-use self::arithmetic::ArithmeticCommand;
-use self::case::CaseCommand;
-use self::simple::SimpleCommand;
-use self::paren::ParenCommand;
-use self::brace::BraceCommand;
-use self::function_def::FunctionDefinition;
-use self::repeat::RepeatCommand;
-use self::r#while::WhileCommand;
-use self::r#for::ForCommand;
-use self::r#if::IfCommand;
-use self::test::TestCommand;
-use std::fmt;
-use std::fmt::Debug;
-use super::{io, Pipe};
-use super::io::redirect::Redirect;
+use crate::{proc_ctrl, Feeder, Script, ShellCore};
 use nix::unistd;
 use nix::unistd::{ForkResult, Pid};
+use std::fmt;
+use std::fmt::Debug;
 
 impl Debug for dyn Command {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -41,7 +41,7 @@ impl Debug for dyn Command {
     }
 }
 
-impl Clone for Box::<dyn Command> {
+impl Clone for Box<dyn Command> {
     fn clone(&self) -> Box<dyn Command> {
         self.boxed_clone()
     }
@@ -49,10 +49,11 @@ impl Clone for Box::<dyn Command> {
 
 pub trait Command {
     fn exec(&mut self, core: &mut ShellCore, pipe: &mut Pipe) -> Result<Option<Pid>, ExecError> {
-        core.db.set_param("LINENO", &self.get_lineno().to_string(), None)?;
-        if self.force_fork() || ( ! pipe.lastpipe && pipe.is_connected() ) {
+        core.db
+            .set_param("LINENO", &self.get_lineno().to_string(), None)?;
+        if self.force_fork() || (!pipe.lastpipe && pipe.is_connected()) {
             self.fork_exec(core, pipe)
-        }else{
+        } else {
             pipe.connect_lastpipe();
             self.nofork_exec(core)
         }
@@ -64,20 +65,24 @@ pub trait Command {
         self.run(core, true)
     }
 
-    fn fork_exec(&mut self, core: &mut ShellCore, pipe: &mut Pipe) -> Result<Option<Pid>, ExecError> {
-        match unsafe{unistd::fork()?} {
+    fn fork_exec(
+        &mut self,
+        core: &mut ShellCore,
+        pipe: &mut Pipe,
+    ) -> Result<Option<Pid>, ExecError> {
+        match unsafe { unistd::fork()? } {
             ForkResult::Child => {
                 if let Err(e) = self.fork_exec_child(core, pipe) {
                     e.print(core);
                     core.db.exit_status = 1;
                 }
                 exit::normal(core)
-            },
+            }
             ForkResult::Parent { child } => {
                 proc_ctrl::set_pgid(core, child, pipe.pgid);
                 pipe.parent_close();
                 Ok(Some(child))
-            },
+            }
         }
     }
 
@@ -91,23 +96,34 @@ pub trait Command {
 
         if result.is_ok() {
             let _ = self.run(core, false);
-        }else{
+        } else {
             core.db.exit_status = 1;
         }
-        self.get_redirects().iter_mut().rev().for_each(|r| r.restore());
+        self.get_redirects()
+            .iter_mut()
+            .rev()
+            .for_each(|r| r.restore());
         result
     }
 
     fn run(&mut self, _: &mut ShellCore, fork: bool) -> Result<(), ExecError>;
     fn get_text(&self) -> String;
-    fn get_one_line_text(&self) -> String {self.get_text().replace("\n", " ")}
+    fn get_one_line_text(&self) -> String {
+        self.get_text().replace("\n", " ")
+    }
     fn get_redirects(&mut self) -> &mut Vec<Redirect>;
-    fn get_lineno(&mut self) -> usize {panic!("IMPLEMENT!!")}
+    fn get_lineno(&mut self) -> usize {
+        panic!("IMPLEMENT!!")
+    }
     fn set_force_fork(&mut self);
     fn boxed_clone(&self) -> Box<dyn Command>;
     fn force_fork(&self) -> bool;
 
-    fn read_heredoc(&mut self, feeder: &mut Feeder, core: &mut ShellCore) -> Result<(), ParseError> {
+    fn read_heredoc(
+        &mut self,
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+    ) -> Result<(), ParseError> {
         for r in self.get_redirects().iter_mut() {
             if r.called_as_heredoc {
                 continue;
@@ -128,12 +144,21 @@ pub trait Command {
     }
 }
 
-pub fn eat_inner_script(feeder: &mut Feeder, core: &mut ShellCore, left: &str, right: Vec<&str>,
-                        ans: &mut Option<Script>, permit_empty: bool) -> Result<bool, ParseError> {
-    if ! feeder.starts_with(left) {
+pub fn eat_inner_script(
+    feeder: &mut Feeder,
+    core: &mut ShellCore,
+    left: &str,
+    right: Vec<&str>,
+    ans: &mut Option<Script>,
+    permit_empty: bool,
+) -> Result<bool, ParseError> {
+    if !feeder.starts_with(left) {
         return Ok(false);
     }
-    feeder.nest.push( (left.to_string(), right.iter().map(|e| e.to_string()).collect()) );
+    feeder.nest.push((
+        left.to_string(),
+        right.iter().map(|e| e.to_string()).collect(),
+    ));
     feeder.consume(left.len());
     let result_script = Script::parse(feeder, core, permit_empty);
     feeder.nest.pop();
@@ -141,7 +166,11 @@ pub fn eat_inner_script(feeder: &mut Feeder, core: &mut ShellCore, left: &str, r
     Ok(ans.is_some())
 }
 
-pub fn eat_blank_with_comment(feeder: &mut Feeder, core: &mut ShellCore, ans_text: &mut String) -> bool {
+pub fn eat_blank_with_comment(
+    feeder: &mut Feeder,
+    core: &mut ShellCore,
+    ans_text: &mut String,
+) -> bool {
     let blank_len = feeder.scanner_blank(core);
     *ans_text += &feeder.consume(blank_len);
 
@@ -153,8 +182,11 @@ pub fn eat_blank_with_comment(feeder: &mut Feeder, core: &mut ShellCore, ans_tex
     true
 }
 
-pub fn eat_blank_lines(feeder: &mut Feeder, core: &mut ShellCore, ans_text: &mut String)
--> Result<(), ParseError> {
+pub fn eat_blank_lines(
+    feeder: &mut Feeder,
+    core: &mut ShellCore,
+    ans_text: &mut String,
+) -> Result<(), ParseError> {
     loop {
         eat_blank_with_comment(feeder, core, ans_text);
         if feeder.starts_with("\n") {
@@ -162,7 +194,7 @@ pub fn eat_blank_lines(feeder: &mut Feeder, core: &mut ShellCore, ans_text: &mut
             continue;
         }
 
-        if feeder.len() == 0 {
+        if feeder.is_empty() {
             feeder.feed_additional_line(core)?;
             continue;
         }
@@ -171,26 +203,33 @@ pub fn eat_blank_lines(feeder: &mut Feeder, core: &mut ShellCore, ans_text: &mut
     }
 }
 
-fn eat_redirect(feeder: &mut Feeder, core: &mut ShellCore,
-                     ans: &mut Vec<Redirect>, ans_text: &mut String) -> bool {
+fn eat_redirect(
+    feeder: &mut Feeder,
+    core: &mut ShellCore,
+    ans: &mut Vec<Redirect>,
+    ans_text: &mut String,
+) -> bool {
     if let Some(r) = Redirect::parse(feeder, core) {
         *ans_text += &r.text.clone();
         ans.push(r);
         true
-    }else{
+    } else {
         false
     }
 }
 
-pub fn eat_redirects(feeder: &mut Feeder, core: &mut ShellCore,
-                     ans_redirects: &mut Vec<Redirect>, ans_text: &mut String) 
-                     -> Result<bool, ParseError> {
+pub fn eat_redirects(
+    feeder: &mut Feeder,
+    core: &mut ShellCore,
+    ans_redirects: &mut Vec<Redirect>,
+    ans_text: &mut String,
+) -> Result<bool, ParseError> {
     let mut exist = false;
     loop {
         eat_blank_with_comment(feeder, core, ans_text);
-        if ! eat_redirect(feeder, core, ans_redirects, ans_text){
+        if !eat_redirect(feeder, core, ans_redirects, ans_text) {
             break;
-        }else{
+        } else {
             exist = true;
         }
     }
@@ -198,17 +237,33 @@ pub fn eat_redirects(feeder: &mut Feeder, core: &mut ShellCore,
     Ok(exist)
 }
 
-pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Box<dyn Command>>, ParseError> {
-    if let Some(a) = FunctionDefinition::parse(feeder, core)? { Ok(Some(Box::new(a))) }
-    else if let Some(a) = SimpleCommand::parse(feeder, core)? { Ok(Some(Box::new(a))) }
-    else if let Some(a) = IfCommand::parse(feeder, core)? { Ok(Some(Box::new(a))) }
-    else if let Some(a) = ArithmeticCommand::parse(feeder, core)? { Ok(Some(Box::new(a))) }
-    else if let Some(a) = ParenCommand::parse(feeder, core, false)? { Ok(Some(Box::new(a))) }
-    else if let Some(a) = BraceCommand::parse(feeder, core)? { Ok(Some(Box::new(a))) }
-    else if let Some(a) = ForCommand::parse(feeder, core)? { Ok(Some(Box::new(a))) }
-    else if let Some(a) = WhileCommand::parse(feeder, core)? { Ok(Some(Box::new(a))) }
-    else if let Some(a) = RepeatCommand::parse(feeder, core)? { Ok(Some(Box::new(a))) }
-    else if let Some(a) = CaseCommand::parse(feeder, core)? { Ok(Some(Box::new(a))) }
-    else if let Some(a) = TestCommand::parse(feeder, core)? { Ok(Some(Box::new(a))) }
-    else{ Ok(None) }
+pub fn parse(
+    feeder: &mut Feeder,
+    core: &mut ShellCore,
+) -> Result<Option<Box<dyn Command>>, ParseError> {
+    if let Some(a) = FunctionDefinition::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = SimpleCommand::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = IfCommand::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = ArithmeticCommand::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = ParenCommand::parse(feeder, core, false)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = BraceCommand::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = ForCommand::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = WhileCommand::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = RepeatCommand::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = CaseCommand::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = TestCommand::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else {
+        Ok(None)
+    }
 }

--- a/src/elements/command/brace.rs
+++ b/src/elements/command/brace.rs
@@ -1,12 +1,12 @@
 //SPDX-FileCopyrightText: 2022 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder, Script};
+use super::{Command, Redirect};
+use crate::elements::command;
 use crate::error::exec::ExecError;
 use crate::error::parse::ParseError;
 use crate::utils::exit;
-use super::{Command, Redirect};
-use crate::elements::command;
+use crate::{Feeder, Script, ShellCore};
 
 #[derive(Debug, Clone, Default)]
 pub struct BraceCommand {
@@ -26,35 +26,48 @@ impl Command for BraceCommand {
         Ok(())
     }
 
-    fn get_text(&self) -> String { self.text.clone() }
-    fn get_redirects(&mut self) -> &mut Vec<Redirect> { &mut self.redirects }
-    fn get_lineno(&mut self) -> usize { self.lineno }
-    fn set_force_fork(&mut self) { self.force_fork = true; }
-    fn boxed_clone(&self) -> Box<dyn Command> {Box::new(self.clone())}
-    fn force_fork(&self) -> bool { self.force_fork }
+    fn get_text(&self) -> String {
+        self.text.clone()
+    }
+    fn get_redirects(&mut self) -> &mut Vec<Redirect> {
+        &mut self.redirects
+    }
+    fn get_lineno(&mut self) -> usize {
+        self.lineno
+    }
+    fn set_force_fork(&mut self) {
+        self.force_fork = true;
+    }
+    fn boxed_clone(&self) -> Box<dyn Command> {
+        Box::new(self.clone())
+    }
+    fn force_fork(&self) -> bool {
+        self.force_fork
+    }
 
     fn pretty_print(&mut self, indent_num: usize) {
-        println!("{} ", "{");
+        println!("{{ ");
         for s in self.script.iter_mut() {
-            s.pretty_print(indent_num+1);
+            s.pretty_print(indent_num + 1);
         }
-        println!("{}", "}");
+        println!("}}");
     }
 }
 
 impl BraceCommand {
-    pub fn parse(feeder: &mut Feeder, core: &mut ShellCore)
-        -> Result<Option<Self>, ParseError> {
-        let mut ans = Self::default();
-        ans.lineno = feeder.lineno;
+    pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Self>, ParseError> {
+        let mut ans = Self {
+            lineno: feeder.lineno,
+            ..Default::default()
+        };
         if command::eat_inner_script(feeder, core, "{", vec!["}"], &mut ans.script, false)? {
-            ans.text.push_str("{");
+            ans.text.push('{');
             ans.text.push_str(&ans.script.as_ref().unwrap().get_text());
             ans.text.push_str(&feeder.consume(1));
 
             command::eat_redirects(feeder, core, &mut ans.redirects, &mut ans.text)?;
             Ok(Some(ans))
-        }else{
+        } else {
             Ok(None)
         }
     }

--- a/src/elements/command/case.rs
+++ b/src/elements/command/case.rs
@@ -1,13 +1,13 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder, Script};
-use crate::error::exec::ExecError;
-use crate::error::parse::ParseError;
+use super::{Command, Redirect};
 use crate::elements::command;
 use crate::elements::word::Word;
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
 use crate::utils::glob;
-use super::{Command, Redirect};
+use crate::{Feeder, Script, ShellCore};
 
 #[derive(Debug, Clone, Default)]
 pub struct CaseCommand {
@@ -21,7 +21,8 @@ pub struct CaseCommand {
 
 impl Command for CaseCommand {
     fn run(&mut self, core: &mut ShellCore, _: bool) -> Result<(), ExecError> {
-        core.db.set_param("LINENO", &self.lineno.to_string(), None)?;
+        core.db
+            .set_param("LINENO", &self.lineno.to_string(), None)?;
         let mut next = false;
         let word = self.word.clone().unwrap();
 
@@ -31,8 +32,8 @@ impl Command for CaseCommand {
         }
 
         let w = match word.eval_for_case_word(core) {
-            Some(w) => w, 
-            _       => "".to_string(),
+            Some(w) => w,
+            _ => "".to_string(),
         };
 
         let extglob = core.shopts.query("extglob");
@@ -40,14 +41,14 @@ impl Command for CaseCommand {
         for e in &mut self.patterns_script_end {
             for pattern in &mut e.0 {
                 let mut exec_script = false;
-                if ! next {
+                if !next {
                     let p = match pattern.eval_for_case_pattern(core) {
-                        Ok(p) => p, 
+                        Ok(p) => p,
                         Err(e) => {
                             core.db.exit_status = 1;
                             e.print(core); //TODO: it should be output at a higher level
                             return Err(e);
-                        },
+                        }
                     };
                     exec_script = glob::parse_and_compare(&w, &p, extglob);
                 }
@@ -65,12 +66,24 @@ impl Command for CaseCommand {
         Ok(())
     }
 
-    fn get_text(&self) -> String { self.text.clone() }
-    fn get_redirects(&mut self) -> &mut Vec<Redirect> { &mut self.redirects }
-    fn get_lineno(&mut self) -> usize { self.lineno }
-    fn set_force_fork(&mut self) { self.force_fork = true; }
-    fn boxed_clone(&self) -> Box<dyn Command> {Box::new(self.clone())}
-    fn force_fork(&self) -> bool { self.force_fork }
+    fn get_text(&self) -> String {
+        self.text.clone()
+    }
+    fn get_redirects(&mut self) -> &mut Vec<Redirect> {
+        &mut self.redirects
+    }
+    fn get_lineno(&mut self) -> usize {
+        self.lineno
+    }
+    fn set_force_fork(&mut self) {
+        self.force_fork = true;
+    }
+    fn boxed_clone(&self) -> Box<dyn Command> {
+        Box::new(self.clone())
+    }
+    fn force_fork(&self) -> bool {
+        self.force_fork
+    }
 }
 
 impl CaseCommand {
@@ -85,12 +98,15 @@ impl CaseCommand {
         }
     }*/
 
-    fn eat_word(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore)
-        -> Result<bool, ParseError> {
+    fn eat_word(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<bool, ParseError> {
         command::eat_blank_with_comment(feeder, core, &mut ans.text);
         let w = match Word::parse(feeder, core, None)? {
             Some(w) => w,
-            _       => return Ok(false),
+            _ => return Ok(false),
         };
 
         ans.text += &w.text;
@@ -99,8 +115,12 @@ impl CaseCommand {
         Ok(true)
     }
 
-    fn eat_patterns(feeder: &mut Feeder, ans: &mut Vec<Word>, text: &mut String, core: &mut ShellCore)
-        -> Result<bool, ParseError> {
+    fn eat_patterns(
+        feeder: &mut Feeder,
+        ans: &mut Vec<Word>,
+        text: &mut String,
+        core: &mut ShellCore,
+    ) -> Result<bool, ParseError> {
         if feeder.starts_with("(") {
             *text += &feeder.consume(1);
         }
@@ -110,10 +130,10 @@ impl CaseCommand {
             if let Some(w) = Word::parse(feeder, core, None)? {
                 *text += &w.text;
                 ans.push(w)
-            }else{
+            } else {
                 return Ok(false);
             }
-    
+
             command::eat_blank_with_comment(feeder, core, text);
 
             if feeder.starts_with(")") {
@@ -126,26 +146,30 @@ impl CaseCommand {
             }
         }
 
-        Ok(ans.len() != 0)
+        Ok(!ans.is_empty())
     }
 
-    pub fn parse(feeder: &mut Feeder, core: &mut ShellCore)
-        -> Result<Option<CaseCommand>, ParseError> {
-        if ! feeder.starts_with("case") {
+    pub fn parse(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+    ) -> Result<Option<CaseCommand>, ParseError> {
+        if !feeder.starts_with("case") {
             return Ok(None);
         }
 
-        let mut ans = Self::default();
-        ans.lineno = feeder.lineno;
-        ans.text = feeder.consume(4);
+        let mut ans = Self {
+            lineno: feeder.lineno,
+            text: feeder.consume(4),
+            ..Default::default()
+        };
 
         command::eat_blank_lines(feeder, core, &mut ans.text)?;
-        if ! Self::eat_word(feeder, &mut ans, core)? {
+        if !Self::eat_word(feeder, &mut ans, core)? {
             return Ok(None);
         }
 
         command::eat_blank_lines(feeder, core, &mut ans.text)?;
-        if ! feeder.starts_with("in") {
+        if !feeder.starts_with("in") {
             return Ok(None);
         }
         ans.text += &feeder.consume(2);
@@ -157,32 +181,41 @@ impl CaseCommand {
             }
 
             let mut patterns = vec![];
-            if ! Self::eat_patterns(feeder, &mut patterns, &mut ans.text, core)? {
+            if !Self::eat_patterns(feeder, &mut patterns, &mut ans.text, core)? {
                 break;
             }
 
             let mut script = None;
-            if command::eat_inner_script(feeder, core, ")", vec![";;&", ";;", ";&", "esac"], &mut script, true)? {
-                ans.text.push_str(")");
+            if command::eat_inner_script(
+                feeder,
+                core,
+                ")",
+                vec![";;&", ";;", ";&", "esac"],
+                &mut script,
+                true,
+            )? {
+                ans.text.push(')');
                 ans.text.push_str(&script.as_ref().unwrap().get_text());
 
                 if feeder.starts_with("esac") {
-                    ans.patterns_script_end.push( (patterns, script.unwrap(), "".to_string() ) );
+                    ans.patterns_script_end
+                        .push((patterns, script.unwrap(), "".to_string()));
                     break;
                 }
 
-                let end_len = if feeder.starts_with(";;&") { 3 }else{ 2 };
+                let end_len = if feeder.starts_with(";;&") { 3 } else { 2 };
                 let end = feeder.consume(end_len);
                 ans.text.push_str(&end);
-                ans.patterns_script_end.push( (patterns, script.unwrap(), end ) );
-            }else{
+                ans.patterns_script_end
+                    .push((patterns, script.unwrap(), end));
+            } else {
                 return Ok(None);
             }
         }
 
         if feeder.starts_with("esac") {
             ans.text += &feeder.consume(4);
-            if ans.patterns_script_end.len() > 0 {
+            if !ans.patterns_script_end.is_empty() {
                 command::eat_redirects(feeder, core, &mut ans.redirects, &mut ans.text)?;
                 ans.lineno = feeder.lineno;
                 return Ok(Some(ans));

--- a/src/elements/command/paren.rs
+++ b/src/elements/command/paren.rs
@@ -1,12 +1,12 @@
 //SPDX-FileCopyrightText: 2022 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder, Script};
+use super::{Command, Pipe, Redirect};
+use crate::elements::command;
 use crate::error::exec::ExecError;
 use crate::error::parse::ParseError;
 use crate::utils::exit;
-use super::{Command, Pipe, Redirect};
-use crate::elements::command;
+use crate::{Feeder, Script, ShellCore};
 use nix::unistd::Pid;
 
 #[derive(Debug, Clone, Default)]
@@ -23,7 +23,7 @@ impl Command for ParenCommand {
     }
 
     fn run(&mut self, core: &mut ShellCore, fork: bool) -> Result<(), ExecError> {
-        if ! fork {
+        if !fork {
             exit::internal(" (no fork for subshell)");
         }
 
@@ -34,15 +34,25 @@ impl Command for ParenCommand {
         Ok(())
     }
 
-    fn get_text(&self) -> String { self.text.clone() }
-    fn get_redirects(&mut self) -> &mut Vec<Redirect> { &mut self.redirects }
-    fn get_lineno(&mut self) -> usize { self.lineno }
-    fn set_force_fork(&mut self) { }
-    fn boxed_clone(&self) -> Box<dyn Command> {Box::new(self.clone())}
-    fn force_fork(&self) -> bool { true }
+    fn get_text(&self) -> String {
+        self.text.clone()
+    }
+    fn get_redirects(&mut self) -> &mut Vec<Redirect> {
+        &mut self.redirects
+    }
+    fn get_lineno(&mut self) -> usize {
+        self.lineno
+    }
+    fn set_force_fork(&mut self) {}
+    fn boxed_clone(&self) -> Box<dyn Command> {
+        Box::new(self.clone())
+    }
+    fn force_fork(&self) -> bool {
+        true
+    }
 
     fn get_one_line_text(&self) -> String {
-        return match &self.script {
+        match &self.script {
             Some(s) => format!("( {} )", s.get_one_line_text()),
             None => "()".to_string(),
         }
@@ -51,29 +61,34 @@ impl Command for ParenCommand {
 
 impl ParenCommand {
     /*
-    pub fn new(text: &str, script: Option<Script>) -> Self {
-        Self {
-            text: text.to_string(),
-            script: script,
-            redirects: vec![],
+        pub fn new(text: &str, script: Option<Script>) -> Self {
+            Self {
+                text: text.to_string(),
+                script: script,
+                redirects: vec![],
+            }
         }
-    }
-*/
-    pub fn parse(feeder: &mut Feeder, core: &mut ShellCore, substitution: bool)
-        -> Result<Option<Self>, ParseError> {
-        let mut ans = Self::default();
-        ans.lineno = feeder.lineno;
+    */
+    pub fn parse(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+        substitution: bool,
+    ) -> Result<Option<Self>, ParseError> {
+        let mut ans = Self {
+            lineno: feeder.lineno,
+            ..Default::default()
+        };
 
         if command::eat_inner_script(feeder, core, "(", vec![")"], &mut ans.script, substitution)? {
-            ans.text.push_str("(");
+            ans.text.push('(');
             ans.text.push_str(&ans.script.as_ref().unwrap().get_text());
             ans.text.push_str(&feeder.consume(1));
 
-            if ! substitution {
+            if !substitution {
                 command::eat_redirects(feeder, core, &mut ans.redirects, &mut ans.text)?;
             }
             Ok(Some(ans))
-        }else{
+        } else {
             Ok(None)
         }
     }

--- a/src/elements/command/repeat.rs
+++ b/src/elements/command/repeat.rs
@@ -1,14 +1,14 @@
 //SPDX-FileCopyrightText: 2022 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
-use crate::error::exec::ExecError;
-use crate::error::parse::ParseError;
 use super::{Command, Redirect};
 use crate::elements::command;
+use crate::elements::expr::arithmetic::ArithmeticExpr;
 use crate::elements::job::Job;
 use crate::elements::word::Word;
-use crate::elements::expr::arithmetic::ArithmeticExpr;
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone, Default)]
 pub struct RepeatCommand {
@@ -23,7 +23,7 @@ pub struct RepeatCommand {
 impl Command for RepeatCommand {
     fn run(&mut self, core: &mut ShellCore, _: bool) -> Result<(), ExecError> {
         let mut f = Feeder::new(&self.times.text);
-        
+
         let n = match ArithmeticExpr::parse(&mut f, core, false, "")? {
             Some(mut a) => a.eval(core)?.parse::<usize>()?,
             None => 0,
@@ -36,34 +36,48 @@ impl Command for RepeatCommand {
         Ok(())
     }
 
-    fn get_text(&self) -> String { self.text.clone() }
-    fn get_redirects(&mut self) -> &mut Vec<Redirect> { &mut self._dummy }
-    fn get_lineno(&mut self) -> usize { self.lineno }
-    fn set_force_fork(&mut self) { self.force_fork = true; }
-    fn boxed_clone(&self) -> Box<dyn Command> {Box::new(self.clone())}
-    fn force_fork(&self) -> bool { self.force_fork }
+    fn get_text(&self) -> String {
+        self.text.clone()
+    }
+    fn get_redirects(&mut self) -> &mut Vec<Redirect> {
+        &mut self._dummy
+    }
+    fn get_lineno(&mut self) -> usize {
+        self.lineno
+    }
+    fn set_force_fork(&mut self) {
+        self.force_fork = true;
+    }
+    fn boxed_clone(&self) -> Box<dyn Command> {
+        Box::new(self.clone())
+    }
+    fn force_fork(&self) -> bool {
+        self.force_fork
+    }
 }
 
 impl RepeatCommand {
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Self>, ParseError> {
-        if ! feeder.starts_with("repeat") {
+        if !feeder.starts_with("repeat") {
             return Ok(None);
         }
 
-        let mut ans = Self::default();
-        ans.lineno = feeder.lineno;
-        ans.text = feeder.consume(6);
+        let mut ans = Self {
+            lineno: feeder.lineno,
+            text: feeder.consume(6),
+            ..Default::default()
+        };
         command::eat_blank_with_comment(feeder, core, &mut ans.text);
-        
+
         ans.times = match Word::parse(feeder, core, None)? {
             Some(w) => w,
-            _       => return Err(ParseError::UnexpectedSymbol("repeat".to_string())),
+            _ => return Err(ParseError::UnexpectedSymbol("repeat".to_string())),
         };
         let _ = command::eat_blank_lines(feeder, core, &mut ans.text);
 
         ans.job = match Job::parse(feeder, core)? {
             Some(j) => j,
-            _       => return Err(ParseError::UnexpectedSymbol("repeat".to_string())),
+            _ => return Err(ParseError::UnexpectedSymbol("repeat".to_string())),
         };
 
         Ok(Some(ans))

--- a/src/elements/command/simple.rs
+++ b/src/elements/command/simple.rs
@@ -2,20 +2,20 @@
 //SPDX-License-Identifier: BSD-3-Clause
 
 pub mod alias;
-pub mod parser;
 pub mod hash;
+pub mod parser;
 pub mod run_internal;
 
 use crate::{proc_ctrl, ShellCore};
 
-use crate::error::exec::ExecError;
-use crate::env;
-use crate::utils::exit;
 use super::{Command, Pipe, Redirect};
 use crate::elements::substitution::Substitution;
 use crate::elements::word::Word;
-use std::sync::atomic::Ordering::Relaxed;
+use crate::env;
+use crate::error::exec::ExecError;
+use crate::utils::exit;
 use nix::unistd::Pid;
+use std::sync::atomic::Ordering::Relaxed;
 
 #[derive(Debug, Clone, Default)]
 pub struct SimpleCommand {
@@ -24,7 +24,7 @@ pub struct SimpleCommand {
     words: Vec<Word>,
     pub args: Vec<String>,
     redirects: Vec<Redirect>,
-    force_fork: bool, 
+    force_fork: bool,
     substitutions_as_args: Vec<Substitution>,
     command_name: String,
     lineno: usize,
@@ -33,11 +33,10 @@ pub struct SimpleCommand {
     command_path: String,
 }
 
-
 impl Command for SimpleCommand {
-    fn exec(&mut self, core: &mut ShellCore, pipe: &mut Pipe)
-    -> Result<Option<Pid>, ExecError> {
-        core.db.set_param("LINENO", &self.lineno.to_string(), None)?;
+    fn exec(&mut self, core: &mut ShellCore, pipe: &mut Pipe) -> Result<Option<Pid>, ExecError> {
+        core.db
+            .set_param("LINENO", &self.lineno.to_string(), None)?;
         if Self::break_continue_or_return(core) {
             return Ok(None);
         }
@@ -50,7 +49,7 @@ impl Command for SimpleCommand {
             self.set_arg(w, core)?;
         }
 
-        if ! self.args.is_empty() && self.args[0].starts_with("%") {
+        if !self.args.is_empty() && self.args[0].starts_with("%") {
             self.redirects.clear();
             self.args.insert(0, "fg".to_string());
         }
@@ -63,10 +62,10 @@ impl Command for SimpleCommand {
 
     fn run(&mut self, core: &mut ShellCore, fork: bool) -> Result<(), ExecError> {
         core.db.push_local();
-        let layer = core.db.get_layer_num()-1;
+        let layer = core.db.get_layer_num() - 1;
         let _ = self.set_local_params(core, layer);
 
-        if ! run_internal::run(self, core)? {
+        if !run_internal::run(self, core)? {
             self.set_environment_variables(core)?;
             proc_ctrl::exec_command(&self.args, core, &self.command_path);
         };
@@ -74,50 +73,65 @@ impl Command for SimpleCommand {
         core.db.pop_local();
 
         match fork {
-            true  => exit::normal(core),
+            true => exit::normal(core),
             false => Ok(()),
         }
     }
 
-    fn get_text(&self) -> String { self.text.clone() }
-    fn get_redirects(&mut self) -> &mut Vec<Redirect> { &mut self.redirects }
-    fn set_force_fork(&mut self) { self.force_fork = true; }
-    fn boxed_clone(&self) -> Box<dyn Command> {Box::new(self.clone())}
-    fn force_fork(&self) -> bool { self.force_fork }
+    fn get_text(&self) -> String {
+        self.text.clone()
+    }
+    fn get_redirects(&mut self) -> &mut Vec<Redirect> {
+        &mut self.redirects
+    }
+    fn set_force_fork(&mut self) {
+        self.force_fork = true;
+    }
+    fn boxed_clone(&self) -> Box<dyn Command> {
+        Box::new(self.clone())
+    }
+    fn force_fork(&self) -> bool {
+        self.force_fork
+    }
 }
 
 impl SimpleCommand {
     fn break_continue_or_return(core: &mut ShellCore) -> bool {
-        core.break_counter > 0 || core.continue_counter > 0 
+        core.break_counter > 0 || core.continue_counter > 0
     }
 
-    pub fn exec_command(&mut self, core: &mut ShellCore, pipe: &mut Pipe)
-    -> Result<Option<Pid>, ExecError> {
+    pub fn exec_command(
+        &mut self,
+        core: &mut ShellCore,
+        pipe: &mut Pipe,
+    ) -> Result<Option<Pid>, ExecError> {
         Self::check_sigint(core)?;
 
         core.db.last_arg = self.args.last().unwrap().clone();
         self.option_x_output(core);
 
-        if core.db.flags.contains('r') {
-            if self.args[0].contains('/') {
-                let msg = format!("{}: restricted: cannot specify `/' in command names", &self.args[0]);
-                return Err(ExecError::Other(msg));
-            }
+        if core.db.flags.contains('r') && self.args[0].contains('/') {
+            let msg = format!(
+                "{}: restricted: cannot specify `/' in command names",
+                &self.args[0]
+            );
+            return Err(ExecError::Other(msg));
         }
 
         if self.force_fork
-        || ( ! pipe.lastpipe && pipe.is_connected() ) 
-        || ( ! core.builtins.contains_key(&self.args[0]) 
-           && ! core.substitution_builtins.contains_key(&self.args[0]) 
-           && ! core.db.functions.contains_key(&self.args[0]) ) {
+            || (!pipe.lastpipe && pipe.is_connected())
+            || (!core.builtins.contains_key(&self.args[0])
+                && !core.substitution_builtins.contains_key(&self.args[0])
+                && !core.db.functions.contains_key(&self.args[0]))
+        {
             self.command_path = hash::get_and_regist(self, core)?;
             self.fork_exec(core, pipe)
-        }else if self.args.len() == 1 && self.args[0] == "exec" {
+        } else if self.args.len() == 1 && self.args[0] == "exec" {
             for r in self.get_redirects().iter_mut() {
                 r.connect(true, core)?;
             }
             Ok(None)
-        }else{
+        } else {
             pipe.connect_lastpipe();
             self.nofork_exec(core)
         }
@@ -134,7 +148,7 @@ impl SimpleCommand {
     fn exec_set_param(&mut self, core: &mut ShellCore) -> Result<Option<Pid>, ExecError> {
         core.db.last_arg = String::new();
         self.option_x_output(core);
-        
+
         for s in self.substitutions.iter_mut() {
             if let Err(e) = s.eval(core, None, false) {
                 core.db.exit_status = 1;
@@ -169,19 +183,19 @@ impl SimpleCommand {
             Ok(ws) => {
                 self.args.extend(ws);
                 Ok(())
-            },
+            }
             Err(e) => {
-             //   e.print(core);
-                if ! core.sigint.load(Relaxed) {
+                //   e.print(core);
+                if !core.sigint.load(Relaxed) {
                     core.db.exit_status = 1;
                 }
                 Err(e)
-            },
+            }
         }
     }
 
     fn option_x_output(&self, core: &mut ShellCore) {
-        if ! core.db.flags.contains('x') {
+        if !core.db.flags.contains('x') {
             return;
         }
 
@@ -196,12 +210,12 @@ impl SimpleCommand {
 
         eprint!("{}", &ps4);
         for a in &self.args {
-            match a.contains(" "){
+            match a.contains(" ") {
                 false => eprint!(" {}", &a),
-                true  => eprint!(" '{}'", &a),
+                true => eprint!(" '{}'", &a),
             }
         }
 
-        eprintln!("");
+        eprintln!();
     }
 }

--- a/src/elements/command/simple/alias.rs
+++ b/src/elements/command/simple/alias.rs
@@ -1,22 +1,26 @@
 //SPDX-FileCopyrightText: 2025 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{Feeder, ShellCore};
 use super::SimpleCommand;
 use crate::elements::command;
+use crate::elements::word::{Word, WordMode};
 use crate::error::parse::ParseError;
-use crate::elements::word::{WordMode, Word};
+use crate::{Feeder, ShellCore};
 
-pub fn set(com: &mut SimpleCommand, word: &Word,
-             core: &mut ShellCore, feeder: &mut Feeder) -> Result<bool, ParseError> {
+pub fn set(
+    com: &mut SimpleCommand,
+    word: &Word,
+    core: &mut ShellCore,
+    feeder: &mut Feeder,
+) -> Result<bool, ParseError> {
     com.continue_alias_check = false;
     let mut w = word.text.clone();
-    if ! core.replace_alias(&mut w) {
+    if !core.replace_alias(&mut w) {
         return Ok(false);
     }
 
     com.continue_alias_check = w.ends_with(" ");
-    let mut feeder_local = Feeder::new(&mut w);
+    let mut feeder_local = Feeder::new(&w);
 
     while SimpleCommand::eat_substitution(&mut feeder_local, com, core)? {
         command::eat_blank_with_comment(&mut feeder_local, core, &mut com.text);
@@ -30,8 +34,8 @@ pub fn set(com: &mut SimpleCommand, word: &Word,
                 }
                 com.text.push_str(&w.text);
                 com.words.push(w);
-            },
-            _    => break,
+            }
+            _ => break,
         }
         command::eat_blank_with_comment(&mut feeder_local, core, &mut com.text);
     }

--- a/src/elements/command/simple/hash.rs
+++ b/src/elements/command/simple/hash.rs
@@ -1,13 +1,15 @@
 //SPDX-FileCopyrightText: 2025 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, utils};
 use super::SimpleCommand;
 use crate::elements::command::ExecError;
+use crate::{utils, ShellCore};
 
-pub fn get_and_regist(com: &mut SimpleCommand, core: &mut ShellCore)
--> Result<String, ExecError> {
-    if ["/", "./", "../"].iter().any(|p| com.args[0].starts_with(p)) {
+pub fn get_and_regist(com: &mut SimpleCommand, core: &mut ShellCore) -> Result<String, ExecError> {
+    if ["/", "./", "../"]
+        .iter()
+        .any(|p| com.args[0].starts_with(p))
+    {
         return Ok(com.args[0].clone());
     }
 
@@ -21,8 +23,7 @@ pub fn get_and_regist(com: &mut SimpleCommand, core: &mut ShellCore)
     Ok(path)
 }
 
-fn resolve_path(arg: &String, core: &mut ShellCore)
--> Result<String, ExecError> {
+fn resolve_path(arg: &str, core: &mut ShellCore) -> Result<String, ExecError> {
     let path = utils::get_command_path(arg, core);
     if path.is_empty() {
         return Ok(path);
@@ -41,6 +42,8 @@ fn resolve_path(arg: &String, core: &mut ShellCore)
 fn count_up(arg: &String, core: &mut ShellCore) {
     match core.db.hash_counter.get_mut(arg) {
         Some(v) => *v += 1,
-        None => {core.db.hash_counter.insert(arg.to_string(), 1);},
+        None => {
+            core.db.hash_counter.insert(arg.to_string(), 1);
+        }
     }
 }

--- a/src/elements/command/simple/run_internal.rs
+++ b/src/elements/command/simple/run_internal.rs
@@ -1,53 +1,56 @@
 //SPDX-FileCopyrightText: 2025 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
 use super::SimpleCommand;
 use crate::error::exec::ExecError;
+use crate::ShellCore;
 
-pub fn run(com: &mut SimpleCommand, core: &mut ShellCore)
--> Result<bool, ExecError> {
-    let ans = run_function(&mut com.args, core) 
-           || run_substitution_builtin(com, core)?
-           || run_builtin(com, core)?;
+pub fn run(com: &mut SimpleCommand, core: &mut ShellCore) -> Result<bool, ExecError> {
+    let ans = run_function(&mut com.args, core)
+        || run_substitution_builtin(com, core)?
+        || run_builtin(com, core)?;
     Ok(ans)
 }
 
-fn run_function(args: &mut Vec<String>, core: &mut ShellCore) -> bool {
+fn run_function(args: &mut [String], core: &mut ShellCore) -> bool {
     match core.db.functions.get_mut(&args[0]) {
-        Some(f) => {f.clone().run_as_command(args, core); true},
+        Some(f) => {
+            f.clone().run_as_command(args, core);
+            true
+        }
         None => false,
     }
 }
 
-pub fn run_builtin(com: &mut SimpleCommand, core: &mut ShellCore)
--> Result<bool, ExecError> {
+pub fn run_builtin(com: &mut SimpleCommand, core: &mut ShellCore) -> Result<bool, ExecError> {
     if com.args.is_empty() {
         eprintln!("ShellCore::run_builtin");
         return Ok(false);
     }
 
-    if ! core.builtins.contains_key(&com.args[0]) {
+    if !core.builtins.contains_key(&com.args[0]) {
         return Ok(false);
     }
 
     let func = core.builtins[&com.args[0]];
-    core.db.exit_status = func(core, &mut com.args);
+    core.db.exit_status = func(core, &com.args);
     Ok(true)
 }
 
-pub fn run_substitution_builtin(com: &mut SimpleCommand, core: &mut ShellCore)
--> Result<bool, ExecError> {
+pub fn run_substitution_builtin(
+    com: &mut SimpleCommand,
+    core: &mut ShellCore,
+) -> Result<bool, ExecError> {
     if com.args.is_empty() {
         eprintln!("ShellCore::run_builtin");
         return Ok(false);
     }
 
-    if ! core.substitution_builtins.contains_key(&com.args[0]) {
+    if !core.substitution_builtins.contains_key(&com.args[0]) {
         return Ok(false);
     }
 
     let func = core.substitution_builtins[&com.args[0]];
-    core.db.exit_status = func(core, &mut com.args, &mut com.substitutions_as_args);
+    core.db.exit_status = func(core, &com.args, &mut com.substitutions_as_args);
     Ok(true)
 }

--- a/src/elements/command/test.rs
+++ b/src/elements/command/test.rs
@@ -1,13 +1,13 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
-use crate::error::exec::ExecError;
-use crate::error::parse::ParseError;
 use super::{Command, Redirect};
 use crate::elements::command;
-use crate::elements::expr::conditional::ConditionalExpr;
 use crate::elements::expr::conditional::elem::CondElem;
+use crate::elements::expr::conditional::ConditionalExpr;
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone, Default)]
 pub struct TestCommand {
@@ -26,37 +26,51 @@ impl Command for TestCommand {
         }
 
         match self.cond.clone().unwrap().eval(core) {
-            Ok(CondElem::Ans(true))  => core.db.exit_status = 0,
+            Ok(CondElem::Ans(true)) => core.db.exit_status = 0,
             Ok(CondElem::Ans(false)) => core.db.exit_status = 1,
-            Err(err_msg)  => {
+            Err(err_msg) => {
                 core.db.exit_status = 2;
                 return Err(err_msg);
-            },
-            _  => {
+            }
+            _ => {
                 core.db.exit_status = 2;
                 return Err(ExecError::Other("unknown error".to_string()));
-            },
-        } ;
+            }
+        };
         Ok(())
     }
 
-    fn get_text(&self) -> String { self.text.clone() }
-    fn get_redirects(&mut self) -> &mut Vec<Redirect> { &mut self.redirects }
-    fn get_lineno(&mut self) -> usize { self.lineno }
-    fn set_force_fork(&mut self) { self.force_fork = true; }
-    fn boxed_clone(&self) -> Box<dyn Command> {Box::new(self.clone())}
-    fn force_fork(&self) -> bool { self.force_fork }
+    fn get_text(&self) -> String {
+        self.text.clone()
+    }
+    fn get_redirects(&mut self) -> &mut Vec<Redirect> {
+        &mut self.redirects
+    }
+    fn get_lineno(&mut self) -> usize {
+        self.lineno
+    }
+    fn set_force_fork(&mut self) {
+        self.force_fork = true;
+    }
+    fn boxed_clone(&self) -> Box<dyn Command> {
+        Box::new(self.clone())
+    }
+    fn force_fork(&self) -> bool {
+        self.force_fork
+    }
 }
 
 impl TestCommand {
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Self>, ParseError> {
-        if ! feeder.starts_with("[[") {
+        if !feeder.starts_with("[[") {
             return Ok(None);
         }
 
-        let mut ans = Self::default();
-        ans.lineno = feeder.lineno;
-        ans.text = feeder.consume(2);
+        let mut ans = Self {
+            lineno: feeder.lineno,
+            text: feeder.consume(2),
+            ..Default::default()
+        };
 
         command::eat_blank_lines(feeder, core, &mut ans.text)?;
 
@@ -64,7 +78,7 @@ impl TestCommand {
             Some(e) => {
                 ans.text += &e.text.clone();
                 ans.cond = Some(e);
-            },
+            }
             None => return Ok(None),
         }
 
@@ -75,7 +89,7 @@ impl TestCommand {
             command::eat_redirects(feeder, core, &mut ans.redirects, &mut ans.text)?;
             return Ok(Some(ans));
         }
-    
+
         Ok(None)
     }
 }

--- a/src/elements/expr/arithmetic.rs
+++ b/src/elements/expr/arithmetic.rs
@@ -6,13 +6,13 @@ pub mod elem;
 mod parser;
 mod rev_polish;
 
-use crate::{Feeder, ShellCore};
-use crate::error::arith::ArithError;
-use crate::error::exec::ExecError;
-use crate::utils::exit;
 use self::calculator::calculate;
 use self::elem::ArithElem;
 use crate::elements::word::Word;
+use crate::error::arith::ArithError;
+use crate::error::exec::ExecError;
+use crate::utils::exit;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone, Default)]
 pub struct ArithmeticExpr {
@@ -35,9 +35,9 @@ impl ArithmeticExpr {
                         return Err(ExecError::ArithError(arith_txt, err));
                     }
                     let text = w.eval_as_value(core)?;
-                    let word = ArithElem::Word( Word::from(&text), *inc);
+                    let word = ArithElem::Word(Word::from(&text), *inc);
                     txt += &word.to_string();
-                },
+                }
                 e => txt += &e.to_string(),
             }
         }
@@ -60,46 +60,43 @@ impl ArithmeticExpr {
         cp.eval_doller(core)?;
 
         let ans = match cp.eval_elems(core, true) {
-            Ok(a) => a, 
+            Ok(a) => a,
             Err(ExecError::ArithError(_, a)) => {
                 let text = cp.text.trim_start().to_string();
-                return Err(ExecError::ArithError(text, a))
-            },
+                return Err(ExecError::ArithError(text, a));
+            }
             Err(e) => return Err(e),
         };
 
         match ans {
-            ArithElem::Integer(n) => {
-                match self.ans_to_string(n) {
-                    Ok(ans) => Ok(ans),
-                    Err(a) => return Err(ExecError::ArithError(cp.text, a)),
-                }
+            ArithElem::Integer(n) => match self.ans_to_string(n) {
+                Ok(ans) => Ok(ans),
+                Err(a) => Err(ExecError::ArithError(cp.text, a)),
             },
-            ArithElem::Float(f)   => Ok(f.to_string()),
-            e => return Err(ExecError::ArithError(cp.text,
-                            ArithError::OperandExpected(e.to_string()).into())),
+            ArithElem::Float(f) => Ok(f.to_string()),
+            e => Err(ExecError::ArithError(
+                cp.text,
+                ArithError::OperandExpected(e.to_string()),
+            )),
         }
     }
 
-    pub fn eval_as_assoc_index(&mut self, core: &mut ShellCore)
-    -> Result<String, ExecError> {
+    pub fn eval_as_assoc_index(&mut self, core: &mut ShellCore) -> Result<String, ExecError> {
         self.eval_doller(core)?;
         let mut ans = String::new();
 
         for e in &self.elements {
             match e {
-                ArithElem::Word(w, i) => {
-                    match w.eval_as_value(core) {
-                        Ok(s) => {
-                            ans += &s;
-                            if *i > 0 {
-                                ans += "++";
-                            }else if *i < 0 {
-                                ans += "--";
-                            }
-                        },
-                        Err(e) => return Err(e),
+                ArithElem::Word(w, i) => match w.eval_as_value(core) {
+                    Ok(s) => {
+                        ans += &s;
+                        if *i > 0 {
+                            ans += "++";
+                        } else if *i < 0 {
+                            ans += "--";
+                        }
                     }
+                    Err(e) => return Err(e),
                 },
                 _ => ans += &e.to_string(),
             }
@@ -113,22 +110,23 @@ impl ArithmeticExpr {
 
         match self.eval_elems(core, true)? {
             ArithElem::Integer(n) => Ok(n),
-            ArithElem::Float(f)   => {
+            ArithElem::Float(f) => {
                 let msg = format!("sush: {}: Not integer. {}", &self.text, f);
                 Err(ExecError::Other(msg))
-            },
+            }
             _ => exit::internal("invalid calculation result"),
         }
     }
 
-    pub fn eval_elems(&mut self, core: &mut ShellCore, permit_empty: bool) -> Result<ArithElem, ExecError> {
-        if self.elements.is_empty() && ! permit_empty {
+    pub fn eval_elems(
+        &mut self,
+        core: &mut ShellCore,
+        permit_empty: bool,
+    ) -> Result<ArithElem, ExecError> {
+        if self.elements.is_empty() && !permit_empty {
             return Err(ArithError::OperandExpected("\")\"".to_string()).into());
         }
-        let es = match self.decompose_increments() {
-            Ok(data)     => data, 
-            Err(err_msg) => return Err(err_msg),
-        };
+        let es = self.decompose_increments()?;
 
         calculate(&es, core)
     }
@@ -142,9 +140,9 @@ impl ArithmeticExpr {
 
         let base = match base_str.parse::<i128>() {
             Ok(b) => b,
-            _     => {
+            _ => {
                 return Err(ArithError::InvalidBase(base_str));
-            },
+            }
         };
 
         if base <= 1 || base > 64 {
@@ -159,7 +157,7 @@ impl ArithmeticExpr {
         }
 
         let mut ans = Self::dec_to_str(&digits, base);
-        if ! self.hide_base {
+        if !self.hide_base {
             ans = base_str + "#" + &ans;
         }
 
@@ -170,21 +168,28 @@ impl ArithmeticExpr {
         Ok(ans)
     }
 
-    fn dec_to_str(nums: &Vec<u8>, base: i128) -> String {
+    fn dec_to_str(nums: &[u8], base: i128) -> String {
         let shift = if base <= 0 {
-            |n| n + '0' as u8
-        }else if base <= 36 {
-            |n| if n < 10 { n + '0' as u8 }
-                else { n - 10 + 'A' as u8 } 
-        }else{
-            |n| if n < 10 { n + '0' as u8 }
-                else if n < 36 { n - 10 + 'a' as u8 } 
-                else if n < 62 { n - 36 + 'A' as u8 } 
-                else if n == 62 { '@' as u8 } 
-                else { '_' as u8 } 
+            |n| n + b'0'
+        } else if base <= 36 {
+            |n| if n < 10 { n + b'0' } else { n - 10 + b'A' }
+        } else {
+            |n| {
+                if n < 10 {
+                    n + b'0'
+                } else if n < 36 {
+                    n - 10 + b'a'
+                } else if n < 62 {
+                    n - 36 + b'A'
+                } else if n == 62 {
+                    b'@'
+                } else {
+                    b'_'
+                }
+            }
         };
 
-        let ascii = nums.iter().map(|n| shift(*n) ).collect::<Vec<u8>>();
+        let ascii = nums.iter().map(|n| shift(*n)).collect::<Vec<u8>>();
         std::str::from_utf8(&ascii).unwrap().to_string()
     }
 
@@ -195,19 +200,21 @@ impl ArithmeticExpr {
 
     fn preinc_to_unarys(&mut self, ans: &mut Vec<ArithElem>, pos: usize, inc: i128) -> i128 {
         let pm = match inc {
-            1  => "+",
+            1 => "+",
             -1 => "-",
             _ => return 0,
-        }.to_string();
-    
-        match (&ans.last(), &self.elements.iter().nth(pos+1)) {
-            (Some(&ArithElem::Variable(_, _, _)), Some(&ArithElem::Word(_, _)))
-                                     => ans.push(ArithElem::BinaryOp(pm.clone())),
-            (_, None)
-            | (_, Some(&ArithElem::Variable(_, _, _))) => return inc,
-            (Some(&ArithElem::Integer(_)), _)
-            | (Some(&ArithElem::Float(_)), _)   => ans.push(ArithElem::BinaryOp(pm.clone())),
-            _                              => ans.push(ArithElem::UnaryOp(pm.clone())),
+        }
+        .to_string();
+
+        match (&ans.last(), &self.elements.get(pos + 1)) {
+            (Some(&ArithElem::Variable(_, _, _)), Some(&ArithElem::Word(_, _))) => {
+                ans.push(ArithElem::BinaryOp(pm.clone()))
+            }
+            (_, None) | (_, Some(&ArithElem::Variable(_, _, _))) => return inc,
+            (Some(&ArithElem::Integer(_)), _) | (Some(&ArithElem::Float(_)), _) => {
+                ans.push(ArithElem::BinaryOp(pm.clone()))
+            }
+            _ => ans.push(ArithElem::UnaryOp(pm.clone())),
         }
         ans.push(ArithElem::UnaryOp(pm));
         0
@@ -227,19 +234,20 @@ impl ArithmeticExpr {
                     }
                     ans.push(e);
                     0
-                },
+                }
                 ArithElem::Increment(n) => self.preinc_to_unarys(&mut ans, i, n),
                 _ => {
                     ans.push(self.elements[i].clone());
                     0
-                },
+                }
             };
         }
 
-        match pre_increment { //↓treated as + or - in error messages
-            1  => Err(ArithError::OperandExpected("+".to_string()).into()),
+        match pre_increment {
+            //↓treated as + or - in error messages
+            1 => Err(ArithError::OperandExpected("+".to_string()).into()),
             -1 => Err(ArithError::OperandExpected("-".to_string()).into()),
-            _  => Ok(ans),
+            _ => Ok(ans),
         }
     }
 

--- a/src/elements/expr/arithmetic/elem.rs
+++ b/src/elements/expr/arithmetic/elem.rs
@@ -1,17 +1,18 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-pub mod int;
 pub mod float;
+pub mod int;
 pub mod ternary;
 pub mod variable;
 
 use super::ArithmeticExpr;
 use super::Word;
-use crate::{ShellCore, utils};
+use crate::elements::substitution::subscript::Subscript;
 use crate::error::arith::ArithError;
 use crate::error::exec::ExecError;
-use crate::elements::substitution::subscript::Subscript;
+use crate::{utils, ShellCore};
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(Debug, Clone)]
 pub enum ArithElem {
@@ -23,11 +24,11 @@ pub enum ArithElem {
     Variable(String, Option<Subscript>, i128), // name + subscript + post increment or decrement
     InParen(ArithmeticExpr),
     Increment(i128), //pre increment
-//    Delimiter(String), //delimiter dividing left and right of &&, ||, and ','
+    //    Delimiter(String), //delimiter dividing left and right of &&, ||, and ','
     /* only for parse */
     Space(String),
     Symbol(String),
-    Word(Word, i128), // Word + post increment or decrement
+    Word(Word, i128),                   // Word + post increment or decrement
     ArrayElem(String, Subscript, i128), // a[1]++
 }
 
@@ -35,53 +36,51 @@ impl ArithElem {
     pub fn order(&self) -> u8 {
         match self {
             ArithElem::Increment(_) => 20,
-            ArithElem::UnaryOp(s) => {
-                match s.as_str() {
-                    "-" | "+" => 19,
-                    _         => 19,
-                }
+            ArithElem::UnaryOp(s) => match s.as_str() {
+                "-" | "+" => 19,
+                _ => 19,
             },
             ArithElem::BinaryOp(s) => {
                 match s.as_str() {
-                    "**"            => 17, 
-                    "*" | "/" | "%" => 16, 
-                    "+" | "-"       => 15, 
-                    "<<" | ">>"     => 14, 
-                    "<=" | ">=" | ">" | "<" => 13, 
-                    "==" | "!="     => 12, 
-                    "&"             => 11, 
-                    "^"             => 10, 
-                    "|"             => 9, 
-                    "&&"             => 8, 
-                    "||"             => 7, 
-                    ","             => 0, 
-                    _               => 2, //substitution
+                    "**" => 17,
+                    "*" | "/" | "%" => 16,
+                    "+" | "-" => 15,
+                    "<<" | ">>" => 14,
+                    "<=" | ">=" | ">" | "<" => 13,
+                    "==" | "!=" => 12,
+                    "&" => 11,
+                    "^" => 10,
+                    "|" => 9,
+                    "&&" => 8,
+                    "||" => 7,
+                    "," => 0,
+                    _ => 2, //substitution
                 }
-            },
+            }
             ArithElem::Ternary(_, _) => 3,
-            _ => 1, 
+            _ => 1,
         }
     }
+}
 
-    pub fn to_string(&self) -> String {
-        match self {
+impl Display for ArithElem {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let s = match self {
             ArithElem::Space(s) => s.to_string(),
             ArithElem::Symbol(s) => s.to_string(),
             ArithElem::InParen(a) => a.text.to_string(),
             ArithElem::Integer(n) => n.to_string(),
-            ArithElem::Float(f) => {
-                let mut ans = f.to_string();
-                if ! ans.contains('.') {
+            ArithElem::Float(fl) => {
+                let mut ans = fl.to_string();
+                if !ans.contains('.') {
                     ans += ".0";
                 }
                 ans
-            },
-            ArithElem::Word(w, inc) => {
-                match inc {
-                    1  => w.text.clone() + "++",
-                    -1 => w.text.clone() + "--",
-                    _  => w.text.clone(),
-                }
+            }
+            ArithElem::Word(w, inc) => match inc {
+                1 => w.text.clone() + "++",
+                -1 => w.text.clone() + "--",
+                _ => w.text.clone(),
             },
             ArithElem::Variable(w, sub, inc) => {
                 let mut ans = w.clone();
@@ -89,12 +88,12 @@ impl ArithElem {
                     ans += &s.text.clone();
                 }
                 match inc {
-                    1  => ans += "++",
+                    1 => ans += "++",
                     -1 => ans += "--",
-                    _  => {},
+                    _ => {}
                 }
                 ans
-            },
+            }
             ArithElem::Ternary(left, right) => {
                 let mut ans = "?".to_string();
                 if let Some(e) = *left.clone() {
@@ -105,7 +104,7 @@ impl ArithElem {
                     ans += &e.text.clone();
                 }
                 ans
-            },
+            }
             ArithElem::UnaryOp(s) => s.clone(),
             ArithElem::BinaryOp(s) => s.clone(),
             ArithElem::Increment(1) => "++".to_string(),
@@ -113,47 +112,51 @@ impl ArithElem {
             ArithElem::ArrayElem(name, subs, inc) => {
                 let mut arr = name.clone() + &subs.text;
                 match inc {
-                    1  => arr += "++",
+                    1 => arr += "++",
                     -1 => arr += "--",
-                    _  => {},
+                    _ => {}
                 }
                 arr
-            },
+            }
             _ => "".to_string(),
-        }
+        };
+        write!(f, "{s}")
     }
+}
 
-    pub fn change_to_value(&mut self, add: i128, core: &mut ShellCore)
-    -> Result<(), ExecError> {
+impl ArithElem {
+    pub fn change_to_value(&mut self, add: i128, core: &mut ShellCore) -> Result<(), ExecError> {
         *self = match self {
             ArithElem::InParen(ref mut a) => a.eval_elems(core, false)?,
             ArithElem::Variable(name, s, inc) => {
-                if add != 0 && *inc != 0 || ! utils::is_name(&name, core) {
+                if add != 0 && *inc != 0 || !utils::is_name(name, core) {
                     return Err(ArithError::OperandExpected(name.to_string()).into());
                 }
 
                 let index = match s {
-                    Some(sub) => sub.eval(core, &name)?,
+                    Some(sub) => sub.eval(core, name)?,
                     None => "".to_string(),
                 };
 
                 match add {
-                    0 => variable::set_and_to_value(&name, &index, core, *inc, false)?,
-                    _ => variable::set_and_to_value(&name, &index, core, add, true)?,
+                    0 => variable::set_and_to_value(name, &index, core, *inc, false)?,
+                    _ => variable::set_and_to_value(name, &index, core, add, true)?,
                 }
-            },
+            }
             _ => return Ok(()),
         };
         Ok(())
     }
 
     pub fn is_operand(&self) -> bool {
-        match &self {
-            ArithElem::Float(_) | ArithElem::Integer(_) |
-            ArithElem::ArrayElem(_, _, _) | ArithElem::Word(_, _) |
-            ArithElem::Variable(_, _, _) | ArithElem::InParen(_) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            ArithElem::Float(_)
+                | ArithElem::Integer(_)
+                | ArithElem::ArrayElem(_, _, _)
+                | ArithElem::Word(_, _)
+                | ArithElem::Variable(_, _, _)
+                | ArithElem::InParen(_)
+        )
     }
 }
-

--- a/src/elements/expr/arithmetic/elem/float.rs
+++ b/src/elements/expr/arithmetic/elem/float.rs
@@ -1,71 +1,94 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{error, ShellCore};
+use super::variable;
+use super::ArithElem;
 use crate::error::arith::ArithError;
 use crate::error::exec::ExecError;
-use super::ArithElem;
-use super::variable;
+use crate::{error, ShellCore};
 
 pub fn unary_calc(op: &str, num: f64, stack: &mut Vec<ArithElem>) -> Result<(), ExecError> {
     match op {
-        "+"  => stack.push( ArithElem::Float(num) ),
-        "-"  => stack.push( ArithElem::Float(-num) ),
-        _ => return Err(ExecError::Other("not supported operator for float number".to_string())),
+        "+" => stack.push(ArithElem::Float(num)),
+        "-" => stack.push(ArithElem::Float(-num)),
+        _ => {
+            return Err(ExecError::Other(
+                "not supported operator for float number".to_string(),
+            ))
+        }
     }
     Ok(())
 }
 
-pub fn bin_calc(op: &str, left: f64, right: f64,
-                stack: &mut Vec<ArithElem>) -> Result<(), ExecError> {
-    let bool_to_01 = |b| { if b { ArithElem::Integer(1) } else { ArithElem::Integer(0) } };
+pub fn bin_calc(
+    op: &str,
+    left: f64,
+    right: f64,
+    stack: &mut Vec<ArithElem>,
+) -> Result<(), ExecError> {
+    let bool_to_01 = |b| {
+        if b {
+            ArithElem::Integer(1)
+        } else {
+            ArithElem::Integer(0)
+        }
+    };
 
     match op {
-        "+"  => stack.push(ArithElem::Float(left + right)),
-        "-"  => stack.push(ArithElem::Float(left - right)),
-        "*"  => stack.push(ArithElem::Float(left * right)),
-        "<="  => stack.push(bool_to_01( left <= right )),
-        ">="  => stack.push(bool_to_01( left >= right )),
-        "<"  => stack.push(bool_to_01( left < right )),
-        ">"  => stack.push(bool_to_01( left > right )),
-        "=="  => stack.push(bool_to_01( left == right )),
-        "!="  => stack.push(bool_to_01( left != right )),
+        "+" => stack.push(ArithElem::Float(left + right)),
+        "-" => stack.push(ArithElem::Float(left - right)),
+        "*" => stack.push(ArithElem::Float(left * right)),
+        "<=" => stack.push(bool_to_01(left <= right)),
+        ">=" => stack.push(bool_to_01(left >= right)),
+        "<" => stack.push(bool_to_01(left < right)),
+        ">" => stack.push(bool_to_01(left > right)),
+        "==" => stack.push(bool_to_01(left == right)),
+        "!=" => stack.push(bool_to_01(left != right)),
         "/" => {
             if right == 0.0 {
                 return Err(ExecError::Other("divided by 0".to_string()));
             }
             stack.push(ArithElem::Float(left / right));
-        },
+        }
         "**" => {
             if right >= 0.0 {
-                let r = right.try_into().unwrap();
+                let r = right;
                 stack.push(ArithElem::Float(left.powf(r)));
-            }else{
-                return Err( ExecError::Other(error::exponent(&right.to_string()) ));
+            } else {
+                return Err(ExecError::Other(error::exponent(&right.to_string())));
             }
-        },
-        _    => return Err(ExecError::Other("not supported operator for float numbers".to_string())),
+        }
+        _ => {
+            return Err(ExecError::Other(
+                "not supported operator for float numbers".to_string(),
+            ))
+        }
     }
 
     Ok(())
 }
 
-pub fn substitute(op: &str, name: &String, index: &String,
-    cur: f64, right: f64, core: &mut ShellCore) -> Result<ArithElem, ExecError> {
+pub fn substitute(
+    op: &str,
+    name: &str,
+    index: &str,
+    cur: f64,
+    right: f64,
+    core: &mut ShellCore,
+) -> Result<ArithElem, ExecError> {
     let new_value = match op {
         "+=" => cur + right,
         "-=" => cur - right,
         "*=" => cur * right,
-        "/=" => {
-            match right == 0.0 {
-                true  => return Err(ArithError::DivZero(right.to_string()).into()),
-                false => cur / right,
-            }
+        "/=" => match right == 0.0 {
+            true => return Err(ArithError::DivZero(right.to_string()).into()),
+            false => cur / right,
         },
-        _   => return Err(ArithError::OperandExpected(op.to_string()).into()),
+        _ => return Err(ArithError::OperandExpected(op.to_string()).into()),
     };
 
-    core.db.set_param2(&name, index, &new_value.to_string(), None)?;
+    core.db
+        .set_param2(name, index, &new_value.to_string(), None)?;
     Ok(ArithElem::Float(new_value))
 }
 
@@ -75,7 +98,7 @@ pub fn parse(s: &str) -> Result<f64, ArithError> {
 
     match (sw.parse::<f64>(), sign.as_str()) {
         (Ok(f), "-") => Ok(-f),
-        (Ok(f), _)   => Ok(f),
-        (Err(_), _)  => Err(ArithError::InvalidNumber(s.to_string())),
+        (Ok(f), _) => Ok(f),
+        (Err(_), _) => Err(ArithError::InvalidNumber(s.to_string())),
     }
 }

--- a/src/elements/expr/arithmetic/elem/int.rs
+++ b/src/elements/expr/arithmetic/elem/int.rs
@@ -1,96 +1,138 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
+use super::variable;
+use super::ArithElem;
 use crate::error::arith::ArithError;
 use crate::error::exec::ExecError;
 use crate::utils::exit;
-use super::ArithElem;
-use super::variable;
+use crate::ShellCore;
 
 pub fn unary_calc(op: &str, num: i128, stack: &mut Vec<ArithElem>) -> Result<(), ExecError> {
     match op {
-        "+"  => stack.push( ArithElem::Integer(num) ),
-        "-"  => stack.push( ArithElem::Integer(-num) ),
-        "!"  => stack.push( ArithElem::Integer(if num == 0 { 1 } else { 0 }) ),
-        "~"  => stack.push( ArithElem::Integer( !num) ),
+        "+" => stack.push(ArithElem::Integer(num)),
+        "-" => stack.push(ArithElem::Integer(-num)),
+        "!" => stack.push(ArithElem::Integer(if num == 0 { 1 } else { 0 })),
+        "~" => stack.push(ArithElem::Integer(!num)),
         _ => exit::internal("unknown unary operator"),
     }
     Ok(())
 }
 
-pub fn bin_calc(op: &str, left: i128, right: i128, stack: &mut Vec<ArithElem>) -> Result<(), ArithError> {
-    let bool_to_01 = |b| { if b { 1 } else { 0 } };
+pub fn bin_calc(
+    op: &str,
+    left: i128,
+    right: i128,
+    stack: &mut Vec<ArithElem>,
+) -> Result<(), ArithError> {
+    let bool_to_01 = |b| {
+        if b {
+            1
+        } else {
+            0
+        }
+    };
 
     let ans = match op {
-        "+"  => left + right,
-        "-"  => left - right,
-        "*"  => left * right,
-        "&"  => left & right,
-        "^"  => left ^ right,
-        "|"  => left | right,
-        "&&"  => bool_to_01( left != 0 && right != 0 ),
-        "||"  => bool_to_01( left != 0 || right != 0 ),
-        "<<"  => if right < 0 {0} else {left << right},
-        ">>"  => if right < 0 {0} else {left >> right},
-        "<="  => bool_to_01( left <= right ),
-        ">="  => bool_to_01( left >= right ),
-        "<"  => bool_to_01( left < right ),
-        ">"  => bool_to_01( left > right ),
-        "=="  => bool_to_01( left == right ),
-        "!="  => bool_to_01( left != right ),
+        "+" => left + right,
+        "-" => left - right,
+        "*" => left * right,
+        "&" => left & right,
+        "^" => left ^ right,
+        "|" => left | right,
+        "&&" => bool_to_01(left != 0 && right != 0),
+        "||" => bool_to_01(left != 0 || right != 0),
+        "<<" => {
+            if right < 0 {
+                0
+            } else {
+                left << right
+            }
+        }
+        ">>" => {
+            if right < 0 {
+                0
+            } else {
+                left >> right
+            }
+        }
+        "<=" => bool_to_01(left <= right),
+        ">=" => bool_to_01(left >= right),
+        "<" => bool_to_01(left < right),
+        ">" => bool_to_01(left > right),
+        "==" => bool_to_01(left == right),
+        "!=" => bool_to_01(left != right),
         "%" | "/" => {
             if right == 0 {
                 return Err(ArithError::DivZero(right.to_string()));
             }
             match op {
                 "%" => left % right,
-                _   => left / right,
+                _ => left / right,
             }
-        },
+        }
         "**" => {
             if right >= 0 {
                 let r = right.try_into().unwrap();
                 left.pow(r)
-            }else{
+            } else {
                 return Err(ArithError::Exponent(right));
             }
-        },
-        _    => exit::internal("unknown binary operator"),
+        }
+        _ => exit::internal("unknown binary operator"),
     };
 
     stack.push(ArithElem::Integer(ans));
     Ok(())
 }
 
-pub fn substitute(op: &str, name: &String, index: &String,
-    cur: i128, right: i128, core: &mut ShellCore) -> Result<ArithElem, ExecError> {
+pub fn substitute(
+    op: &str,
+    name: &str,
+    index: &str,
+    cur: i128,
+    right: i128,
+    core: &mut ShellCore,
+) -> Result<ArithElem, ExecError> {
     let new_value = match op {
         "+=" => cur + right,
         "-=" => cur - right,
         "*=" => cur * right,
-        "&="  => cur & right,
-        "^="  => cur ^ right,
-        "|="  => cur | right,
-        "<<="  => if right < 0 {0} else {cur << right},
-        ">>="  => if right < 0 {0} else {cur >> right},
+        "&=" => cur & right,
+        "^=" => cur ^ right,
+        "|=" => cur | right,
+        "<<=" => {
+            if right < 0 {
+                0
+            } else {
+                cur << right
+            }
+        }
+        ">>=" => {
+            if right < 0 {
+                0
+            } else {
+                cur >> right
+            }
+        }
         "/=" | "%=" => {
             if right == 0 {
                 return Err(ArithError::DivZero(right.to_string()).into());
             }
             match op == "%=" {
-                true  => cur % right,
+                true => cur % right,
                 false => cur / right,
             }
-        },
-        _   => return Err(ArithError::OperandExpected(op.to_string()).into()),
+        }
+        _ => return Err(ArithError::OperandExpected(op.to_string()).into()),
     };
 
-    core.db.set_param2(&name, index, &new_value.to_string(), None)?;
+    core.db
+        .set_param2(name, index, &new_value.to_string(), None)?;
     Ok(ArithElem::Integer(new_value))
 }
 
-fn parse_with_base(base: i128, s: &mut String, org: &str) -> Result<i128, ArithError> {
+fn parse_with_base(base: i128, s: &mut str, org: &str) -> Result<i128, ArithError> {
     if s.is_empty() {
         return Err(ArithError::InvalidIntConst(org.to_string()));
     }
@@ -98,25 +140,25 @@ fn parse_with_base(base: i128, s: &mut String, org: &str) -> Result<i128, ArithE
     let mut ans = 0;
     for ch in s.chars() {
         ans *= base;
-        let num = if ch >= '0' && ch <= '9' {
+        let num = if ch.is_ascii_digit() {
             ch as i128 - '0' as i128
-        }else if ch >= 'a' && ch <= 'z' {
+        } else if ch.is_ascii_lowercase() {
             ch as i128 - 'a' as i128 + 10
-        }else if ch >= 'A' && ch <= 'Z' {
+        } else if ch.is_ascii_uppercase() {
             match base <= 36 {
-                true  => ch as i128 - 'A' as i128 + 10,
+                true => ch as i128 - 'A' as i128 + 10,
                 false => ch as i128 - 'A' as i128 + 36,
             }
-        }else if ch == '@' {
+        } else if ch == '@' {
             62
-        }else if ch == '_' {
+        } else if ch == '_' {
             63
-        }else{
+        } else {
             return Err(ArithError::InvalidNumber(org.to_string()));
         };
 
         match num < base {
-            true  => ans += num,
+            true => ans += num,
             false => return Err(ArithError::ValueTooGreatForBase(org.to_string())),
         }
     }
@@ -142,15 +184,13 @@ fn get_base(s: &mut String) -> Result<i128, ArithError> {
 
     if let Some(n) = s.find("#") {
         let base_str = s[..n].to_string();
-        *s = s[(n+1)..].to_string();
+        *s = s[(n + 1)..].to_string();
         return match base_str.parse::<i128>() {
-            Ok(n) => {
-                match n <= 64 {
-                    true  => Ok(n),
-                    false => Err(ArithError::InvalidBase(s_org.to_string())),
-                }
+            Ok(n) => match n <= 64 {
+                true => Ok(n),
+                false => Err(ArithError::InvalidBase(s_org.to_string())),
             },
-            _     => Err(ArithError::InvalidBase(s_org.to_string())),
+            _ => Err(ArithError::InvalidBase(s_org.to_string())),
         };
     }
 
@@ -158,8 +198,7 @@ fn get_base(s: &mut String) -> Result<i128, ArithError> {
 }
 
 pub fn parse(s: &str) -> Result<i128, ArithError> {
-    if s.find('\'').is_some() 
-    || s.find('.').is_some() {
+    if s.find('\'').is_some() || s.find('.').is_some() {
         return Err(ArithError::InvalidNumber(s.to_string()));
     }
     if s.is_empty() {
@@ -172,8 +211,7 @@ pub fn parse(s: &str) -> Result<i128, ArithError> {
     let n = parse_with_base(base, &mut sw, s)?;
 
     match sign.as_str() {
-        "-" => Ok(-n), 
-        _   => Ok(n), 
+        "-" => Ok(-n),
+        _ => Ok(n),
     }
 }
-

--- a/src/elements/expr/arithmetic/elem/ternary.rs
+++ b/src/elements/expr/arithmetic/elem/ternary.rs
@@ -1,15 +1,18 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
+use super::super::calculator;
+use super::super::{ArithElem, ArithmeticExpr};
 use crate::error::arith::ArithError;
 use crate::error::exec::ExecError;
-use super::super::{ArithmeticExpr, ArithElem};
-use super::super::calculator;
+use crate::ShellCore;
 
-pub fn operation(left: &Option<ArithmeticExpr>, right: &Option<ArithmeticExpr>,
-    stack: &mut Vec<ArithElem>, core: &mut ShellCore) -> Result<(), ExecError> {
-
+pub fn operation(
+    left: &Option<ArithmeticExpr>,
+    right: &Option<ArithmeticExpr>,
+    stack: &mut Vec<ArithElem>,
+    core: &mut ShellCore,
+) -> Result<(), ExecError> {
     if left.is_none() {
         return Err(ArithError::ExpressionExpected(":".to_string()).into());
     }
@@ -32,10 +35,14 @@ pub fn operation(left: &Option<ArithmeticExpr>, right: &Option<ArithmeticExpr>,
 
     let ans = match calculator::pop_operand(stack, core)? {
         ArithElem::Integer(0) => right.eval_in_cond(core)?,
-        ArithElem::Float(_) => return Err(ExecError::Other("float condition is not permitted".to_string())),
+        ArithElem::Float(_) => {
+            return Err(ExecError::Other(
+                "float condition is not permitted".to_string(),
+            ))
+        }
         _ => left.eval_in_cond(core)?,
     };
 
-    stack.push( ans );
+    stack.push(ans);
     Ok(())
 }

--- a/src/elements/expr/arithmetic/elem/variable.rs
+++ b/src/elements/expr/arithmetic/elem/variable.rs
@@ -1,29 +1,28 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{Feeder, ShellCore};
+use super::super::ArithElem;
+use super::{float, int};
 use crate::elements::expr::arithmetic::ArithmeticExpr;
 use crate::error::arith::ArithError;
 use crate::error::exec::ExecError;
 use crate::utils;
 use crate::utils::exit;
-use super::super::ArithElem;
-use super::{float, int};
+use crate::{Feeder, ShellCore};
 
-fn to_num(w: &str, sub: &String, core: &mut ShellCore) -> Result<ArithElem, ExecError> {
+fn to_num(w: &str, sub: &str, core: &mut ShellCore) -> Result<ArithElem, ExecError> {
     if w.find('\'').is_some() {
         return Err(ArithError::OperandExpected(w.to_string()).into());
     }
 
-    let name = w.to_string();//w.eval_as_value(core)?;
+    let name = w.to_string(); //w.eval_as_value(core)?;
     str_to_num(&name, sub, core)
 }
 
-pub fn str_to_num(name: &str, sub: &String, 
-                  core: &mut ShellCore) -> Result<ArithElem, ExecError> {
+pub fn str_to_num(name: &str, sub: &str, core: &mut ShellCore) -> Result<ArithElem, ExecError> {
     let mut name = name.to_string();
 
-    const RESOLVE_LIMIT: i32 = 100;//000;
+    const RESOLVE_LIMIT: i32 = 100; //000;
 
     for i in 0..RESOLVE_LIMIT {
         if utils::is_name(&name, core) {
@@ -38,77 +37,86 @@ pub fn str_to_num(name: &str, sub: &String,
     /* name is not a name here */
 
     match try_parse_to_num(&name) {
-        Ok(e)  => Ok(e),
+        Ok(e) => Ok(e),
         Err(_) => resolve_arithmetic_op(&name, core),
     }
 }
 
 fn resolve_arithmetic_op(name: &str, core: &mut ShellCore) -> Result<ArithElem, ExecError> {
-    let mut f = Feeder::new(&name);
+    let mut f = Feeder::new(name);
     let mut parsed = match ArithmeticExpr::parse_after_eval(&mut f, core, "") {
         Ok(Some(p)) => p,
-        _    => return Err(ArithError::OperandExpected(name.to_string()).into()),
+        _ => return Err(ArithError::OperandExpected(name.to_string()).into()),
     };
-
 
     parsed.eval_elems(core, true)
 }
 
 fn try_parse_to_num(name: &str) -> Result<ArithElem, ExecError> {
     if name.contains('.') {
-        let f = float::parse(&name)?;
+        let f = float::parse(name)?;
         Ok(ArithElem::Float(f))
-    }else{
-        let n = int::parse(&name)?;
-        Ok( ArithElem::Integer(n) )
+    } else {
+        let n = int::parse(name)?;
+        Ok(ArithElem::Integer(n))
     }
 }
 
-pub fn set_and_to_value(name: &str, sub: &String, core: &mut ShellCore,
-                        inc: i128, pre: bool) -> Result<ArithElem, ExecError> {
-    match str_to_num(&name, sub, core) {
-        Ok(ArithElem::Integer(n))        => {
+pub fn set_and_to_value(
+    name: &str,
+    sub: &str,
+    core: &mut ShellCore,
+    inc: i128,
+    pre: bool,
+) -> Result<ArithElem, ExecError> {
+    match str_to_num(name, sub, core) {
+        Ok(ArithElem::Integer(n)) => {
             if inc != 0 {
-                core.db.set_param2(&name, sub, &(n + inc).to_string(), None)?;
+                core.db
+                    .set_param2(name, sub, &(n + inc).to_string(), None)?;
             }
             match pre {
-                true  => Ok(ArithElem::Integer(n+inc)),
+                true => Ok(ArithElem::Integer(n + inc)),
                 false => Ok(ArithElem::Integer(n)),
             }
-        },
-        Ok(ArithElem::Float(n))        => {
+        }
+        Ok(ArithElem::Float(n)) => {
             if inc != 0 {
-                core.db.set_param2(&name, sub, &(n + inc as f64).to_string(), None)?;
+                core.db
+                    .set_param2(name, sub, &(n + inc as f64).to_string(), None)?;
             }
             match pre {
-                true  => Ok(ArithElem::Float(n+inc as f64)),
+                true => Ok(ArithElem::Float(n + inc as f64)),
                 false => Ok(ArithElem::Float(n)),
             }
-        },
+        }
         Ok(_) => exit::internal("unknown element"),
-        Err(err_msg) => return Err(err_msg), 
+        Err(err_msg) => Err(err_msg),
     }
 }
 
 pub fn get_sign(s: &mut String) -> String {
     *s = s.trim().to_string();
     match s.starts_with("+") || s.starts_with("-") {
-        true  => {
+        true => {
             let c = s.remove(0).to_string();
             *s = s.trim().to_string();
             c
-        },
+        }
         false => "+".to_string(),
     }
 }
 
-pub fn substitution(op: &str, stack: &mut Vec<ArithElem>, core: &mut ShellCore)
--> Result<(), ExecError> {
+pub fn substitution(
+    op: &str,
+    stack: &mut Vec<ArithElem>,
+    core: &mut ShellCore,
+) -> Result<(), ExecError> {
     let mut right = match stack.pop() {
         Some(mut e) => {
             e.change_to_value(0, core)?;
             e
-        },
+        }
         _ => return Err(ArithError::OperandExpected(op.to_string()).into()),
     };
 
@@ -121,52 +129,63 @@ pub fn substitution(op: &str, stack: &mut Vec<ArithElem>, core: &mut ShellCore)
         return Ok(());
     }
 
-    Err(ArithError::AssignmentToNonVariable(op.to_string() + &right.to_string()).into() )
+    Err(ArithError::AssignmentToNonVariable(op.to_string() + &right.to_string()).into())
 }
 
-fn subs(op: &str, w: &str, sub: &String, right_value: &mut ArithElem, core: &mut ShellCore)
-                                      -> Result<ArithElem, ExecError> {
+fn subs(
+    op: &str,
+    w: &str,
+    sub: &str,
+    right_value: &mut ArithElem,
+    core: &mut ShellCore,
+) -> Result<ArithElem, ExecError> {
     if w.find('\'').is_some() {
         return Err(ArithError::OperandExpected(w.to_string()).into());
     }
 
-    let name = w.to_string();//w.eval_as_value(core)?;
+    let name = w.to_string(); //w.eval_as_value(core)?;
     let right_str = right_value.to_string();
 
     match op {
         "=" => {
             core.db.set_param2(&name, sub, &right_str, None)?;
             return Ok(right_value.clone());
-        },
+        }
         "+=" => {
             let mut val_str = core.db.get_elem_or_param(&name, sub)?;
-            if val_str == "" {
+            if val_str.is_empty() {
                 val_str = "0".to_string();
             }
             if let Ok(left) = val_str.parse::<i128>() {
-                match right_value {
-                    ArithElem::Integer(n) => {
-                        core.db.set_param2(&name, sub, &(left + *n).to_string(), None)?;
-                        return Ok(ArithElem::Integer(left + *n));
-                    },
-                    _ => {},
+                if let ArithElem::Integer(n) = right_value {
+                    core.db
+                        .set_param2(&name, sub, &(left + *n).to_string(), None)?;
+                    return Ok(ArithElem::Integer(left + *n));
                 }
-            }else if let Ok(left) = val_str.parse::<f64>() {
+            } else if let Ok(left) = val_str.parse::<f64>() {
                 if let ArithElem::Float(f) = right_value {
-                    core.db.set_param2(&name, sub, &(left + *f).to_string(), None)?;
+                    core.db
+                        .set_param2(&name, sub, &(left + *f).to_string(), None)?;
                     return Ok(ArithElem::Float(left + *f));
                 }
             }
-        },
-        _   => {},
+        }
+        _ => {}
     }
 
     match (to_num(w, sub, core)?, right_value) {
-        (ArithElem::Integer(cur), ArithElem::Integer(right)) => Ok(int::substitute(op, &name, sub, cur, *right, core)?),
-        (ArithElem::Float(cur), ArithElem::Integer(right)) => Ok(float::substitute(op, &name, sub, cur, *right as f64, core)?),
-        (ArithElem::Float(cur), ArithElem::Float(right)) => Ok(float::substitute(op, &name, sub, cur, *right, core)?),
-        (ArithElem::Integer(cur), ArithElem::Float(right)) => Ok(float::substitute(op, &name, sub, cur as f64, *right, core)?),
+        (ArithElem::Integer(cur), ArithElem::Integer(right)) => {
+            Ok(int::substitute(op, &name, sub, cur, *right, core)?)
+        }
+        (ArithElem::Float(cur), ArithElem::Integer(right)) => {
+            Ok(float::substitute(op, &name, sub, cur, *right as f64, core)?)
+        }
+        (ArithElem::Float(cur), ArithElem::Float(right)) => {
+            Ok(float::substitute(op, &name, sub, cur, *right, core)?)
+        }
+        (ArithElem::Integer(cur), ArithElem::Float(right)) => {
+            Ok(float::substitute(op, &name, sub, cur as f64, *right, core)?)
+        }
         _ => Err(ExecError::Other("not supported yet".to_string())),
     }
 }
-

--- a/src/elements/expr/arithmetic/parser.rs
+++ b/src/elements/expr/arithmetic/parser.rs
@@ -1,13 +1,13 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
-use crate::error::exec::ExecError;
-use crate::error::parse::ParseError;
+use super::elem::{float, int};
+use super::{ArithElem, ArithmeticExpr};
 use crate::elements::substitution::subscript::Subscript;
 use crate::elements::word::{Word, WordMode};
-use super::{ArithmeticExpr, ArithElem};
-use super::elem::{int, float};
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
 
 impl ArithmeticExpr {
     fn eat_space(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> Option<ArithElem> {
@@ -27,19 +27,19 @@ impl ArithmeticExpr {
         } else if feeder.starts_with("--") {
             ans.text += &feeder.consume(2);
             -1
-        } else{
+        } else {
             0
         }
     }
 
     fn eat_incdec(feeder: &mut Feeder, ans: &mut Self) -> bool {
-        if feeder.starts_with("++") && ! feeder.starts_with("+++") {
+        if feeder.starts_with("++") && !feeder.starts_with("+++") {
             ans.text += &feeder.consume(2);
-            ans.elements.push( ArithElem::Increment(1) );
-        }else if feeder.starts_with("--") && ! feeder.starts_with("---") {
+            ans.elements.push(ArithElem::Increment(1));
+        } else if feeder.starts_with("--") && !feeder.starts_with("---") {
             ans.text += &feeder.consume(2);
-            ans.elements.push( ArithElem::Increment(-1) );
-        }else {
+            ans.elements.push(ArithElem::Increment(-1));
+        } else {
             return false;
         };
         true
@@ -50,15 +50,18 @@ impl ArithmeticExpr {
             let symbol = feeder.consume(1);
             ans.in_ternary = symbol == "?";
             ans.text += &symbol.clone();
-            ans.elements.push( ArithElem::Symbol(symbol));
+            ans.elements.push(ArithElem::Symbol(symbol));
             return true;
         }
 
         false
     }
 
-    fn eat_num(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore)
-    -> Result<bool, ExecError> {
+    fn eat_num(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<bool, ExecError> {
         let len = feeder.scanner_arith_number(core);
         if len == 0 {
             return Ok(false);
@@ -67,56 +70,65 @@ impl ArithmeticExpr {
         let w = feeder.consume(len);
         ans.text += &w.clone();
 
-        if ! w.contains('.') {
+        if !w.contains('.') {
             match int::parse(&w) {
                 Ok(n) => {
-                    ans.elements.push( ArithElem::Integer(n) );
+                    ans.elements.push(ArithElem::Integer(n));
                     return Ok(true);
-                },
+                }
                 Err(e) => {
                     return Err(ExecError::ArithError(w.to_string(), e));
-                },
+                }
             }
         }
 
         if let Ok(f) = float::parse(&w) {
-            ans.elements.push( ArithElem::Float(f) );
+            ans.elements.push(ArithElem::Float(f));
             return Ok(true);
         }
 
-        ans.elements.push( ArithElem::Variable(w.clone(), None, 0) );
+        ans.elements.push(ArithElem::Variable(w.clone(), None, 0));
         Ok(true)
     }
 
-    fn eat_conditional_op(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore)
-    -> Result<bool, ExecError> {
-        if ! feeder.starts_with("?") {
+    fn eat_conditional_op(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<bool, ExecError> {
+        if !feeder.starts_with("?") {
             return Ok(false);
         }
- 
+
         ans.text += &feeder.consume(1);
         let left = Self::parse_after_eval(feeder, core, "?")?;
-        if left.is_some() {
-            ans.text += &left.as_ref().unwrap().text;
+        if let Some(ref left_val) = &left {
+            ans.text += &left_val.text;
         }
 
-        if ! feeder.starts_with(":") {
-            ans.elements.push(ArithElem::Ternary(Box::new(left), Box::new(None)));
+        if !feeder.starts_with(":") {
+            ans.elements
+                .push(ArithElem::Ternary(Box::new(left), Box::new(None)));
             return Ok(true);
         }
 
         ans.text += &feeder.consume(1);
         let right = Self::parse_after_eval(feeder, core, ":")?;
-        if right.is_some() {
-            ans.text += &right.as_ref().unwrap().text;
+        if let Some(ref right_val) = &right {
+            ans.text += &right_val.text;
         }
 
-        ans.elements.push(ArithElem::Ternary(Box::new(left), Box::new(right)));
+        ans.elements
+            .push(ArithElem::Ternary(Box::new(left), Box::new(right)));
         Ok(true)
     }
 
-    fn eat_array_elem(feeder: &mut Feeder, ans: &mut Self,
-                      core: &mut ShellCore, internal: bool) -> Result<bool, ParseError> {
+    fn eat_array_elem(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+        internal: bool,
+    ) -> Result<bool, ParseError> {
         let len = feeder.scanner_name(core);
         if len == 0 {
             return Ok(false);
@@ -130,23 +142,30 @@ impl ArithmeticExpr {
             let sp = Self::eat_space(feeder, ans, core);
             let suffix = Self::eat_suffix(feeder, ans);
             if internal {
-                ans.elements.push( ArithElem::Variable(name.clone(), Some(s), suffix) );
-            }else{
-                ans.elements.push( ArithElem::ArrayElem(name.clone(), s, suffix) );
+                ans.elements
+                    .push(ArithElem::Variable(name.clone(), Some(s), suffix));
+            } else {
+                ans.elements
+                    .push(ArithElem::ArrayElem(name.clone(), s, suffix));
             }
-            if ! internal && sp.is_some() {
-                ans.elements.push(sp.unwrap());
+            if !internal {
+                if let Some(sp_val) = sp {
+                    ans.elements.push(sp_val);
+                }
             }
-        }else{
+        } else {
             let sp = Self::eat_space(feeder, ans, core);
             let suffix = Self::eat_suffix(feeder, ans);
             if internal {
-                ans.elements.push( ArithElem::Variable(name.clone(), None, suffix) );
-            }else{
-                ans.elements.push( ArithElem::Word(Word::from(name), suffix) );
+                ans.elements
+                    .push(ArithElem::Variable(name.clone(), None, suffix));
+            } else {
+                ans.elements.push(ArithElem::Word(Word::from(name), suffix));
             }
-            if ! internal && sp.is_some() {
-                ans.elements.push(sp.unwrap());
+            if !internal {
+                if let Some(sp_val) = sp {
+                    ans.elements.push(sp_val);
+                }
             }
         };
 
@@ -159,9 +178,10 @@ impl ArithmeticExpr {
             //let sp = Self::eat_space(feeder, ans, core);
             let suffix = Self::eat_suffix(feeder, ans);
             if internal {
-                ans.elements.push( ArithElem::Variable(w.text.clone(), None, suffix) );
-            }else {
-                ans.elements.push( ArithElem::Word(w, suffix) );
+                ans.elements
+                    .push(ArithElem::Variable(w.text.clone(), None, suffix));
+            } else {
+                ans.elements.push(ArithElem::Word(w, suffix));
             }
             /*
             if ! internal && sp.is_some() {
@@ -181,8 +201,8 @@ impl ArithmeticExpr {
 
         let mut s = feeder.consume(len);
         ans.text += &s.clone();
-        ans.hide_base = s.find("##").is_some();
-        s.retain(|c| '0' <= c && c <= '9');
+        ans.hide_base = s.contains("##");
+        s.retain(|c: char| c.is_ascii_digit());
         ans.output_base = s;
         true
     }
@@ -195,36 +215,43 @@ impl ArithmeticExpr {
         }
 
         let s = match feeder.scanner_unary_operator(core) {
-            0   => return false,
+            0 => return false,
             len => feeder.consume(len),
         };
 
         ans.text += &s.clone();
-        ans.elements.push( ArithElem::UnaryOp(s) );
+        ans.elements.push(ArithElem::UnaryOp(s));
         true
     }
 
-    fn eat_paren_internal(feeder: &mut Feeder, core: &mut ShellCore, ans: &mut Self)
-    -> Result<bool, ExecError> {
-        if ! feeder.starts_with("(") {
+    fn eat_paren_internal(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+        ans: &mut Self,
+    ) -> Result<bool, ExecError> {
+        if !feeder.starts_with("(") {
             return Ok(false);
         }
 
         ans.text += &feeder.consume(1);
         let arith = Self::parse_after_eval(feeder, core, "(")?;
-        if arith.is_none() || ! feeder.starts_with(")") {
+        if arith.is_none() || !feeder.starts_with(")") {
             return Ok(false);
         }
 
         ans.text += &arith.as_ref().unwrap().text;
-        ans.elements.push( ArithElem::InParen(arith.unwrap()) );
+        ans.elements.push(ArithElem::InParen(arith.unwrap()));
 
         ans.text += &feeder.consume(1);
-        return Ok(true);
+        Ok(true)
     }
 
-    fn eat_paren(feeder: &mut Feeder, core: &mut ShellCore, ans: &mut Self) -> Result<bool, ParseError> {
-        if ! feeder.starts_with("(") {
+    fn eat_paren(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+        ans: &mut Self,
+    ) -> Result<bool, ParseError> {
+        if !feeder.starts_with("(") {
             return Ok(false);
         }
 
@@ -232,7 +259,7 @@ impl ArithmeticExpr {
         ans.text += &paren.clone();
         ans.elements.push(ArithElem::Symbol(paren));
         let arith = Self::parse(feeder, core, true, "(")?;
-        if arith.is_none() || ! feeder.starts_with(")") {
+        if arith.is_none() || !feeder.starts_with(")") {
             return Ok(false);
         }
         ans.text += &arith.as_ref().unwrap().text;
@@ -241,11 +268,10 @@ impl ArithmeticExpr {
         let paren = feeder.consume(1);
         ans.text += &paren.clone();
         ans.elements.push(ArithElem::Symbol(paren));
-        return Ok(true);
+        Ok(true)
     }
 
-    fn eat_binary_operator(feeder: &mut Feeder, ans: &mut Self,
-                           core: &mut ShellCore) -> bool {
+    fn eat_binary_operator(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> bool {
         let len = feeder.scanner_binary_operator(core);
         if len == 0 {
             return false;
@@ -253,49 +279,58 @@ impl ArithmeticExpr {
 
         let s = feeder.consume(len);
         ans.text += &s.clone();
-        ans.elements.push( ArithElem::BinaryOp(s) );
+        ans.elements.push(ArithElem::BinaryOp(s));
         true
     }
 
-    pub fn parse_after_eval(feeder: &mut Feeder, core: &mut ShellCore, left: &str)
-        -> Result<Option<Self>, ExecError> {
+    pub fn parse_after_eval(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+        left: &str,
+    ) -> Result<Option<Self>, ExecError> {
         let mut ans = ArithmeticExpr::new();
 
         loop {
             Self::eat_space(feeder, &mut ans, core);
 
-            if left == "[" && feeder.starts_with("]") 
-            || left == "?" && feeder.starts_with(":")
-            || left == ":" && ( feeder.starts_with("]") || feeder.starts_with(":") ) {
+            if left == "[" && feeder.starts_with("]")
+                || left == "?" && feeder.starts_with(":")
+                || left == ":" && (feeder.starts_with("]") || feeder.starts_with(":"))
+            {
                 break;
             }
 
-            if left == ":" { //substitution cannot exist after ":" of a ternary
-                if ! feeder.starts_with("==")
-                && feeder.scanner_substitution(core) > 0 {
+            if left == ":" {
+                //substitution cannot exist after ":" of a ternary
+                if !feeder.starts_with("==") && feeder.scanner_substitution(core) > 0 {
                     break;
                 }
             }
 
-            if Self::eat_output_format(feeder, &mut ans, core) 
-            || Self::eat_conditional_op(feeder, &mut ans, core)?
-            || Self::eat_incdec(feeder, &mut ans) 
-            || Self::eat_unary_operator(feeder, &mut ans, core)
-            || Self::eat_paren_internal(feeder, core, &mut ans)?
-            || Self::eat_binary_operator(feeder, &mut ans, core)
-            || Self::eat_array_elem(feeder, &mut ans, core, true)?
-            || Self::eat_num(feeder, &mut ans, core)?
-            || Self::eat_word(feeder, &mut ans, core, true) { 
+            if Self::eat_output_format(feeder, &mut ans, core)
+                || Self::eat_conditional_op(feeder, &mut ans, core)?
+                || Self::eat_incdec(feeder, &mut ans)
+                || Self::eat_unary_operator(feeder, &mut ans, core)
+                || Self::eat_paren_internal(feeder, core, &mut ans)?
+                || Self::eat_binary_operator(feeder, &mut ans, core)
+                || Self::eat_array_elem(feeder, &mut ans, core, true)?
+                || Self::eat_num(feeder, &mut ans, core)?
+                || Self::eat_word(feeder, &mut ans, core, true)
+            {
                 continue;
             }
 
             break;
         }
-        return Ok(Some(ans));
+        Ok(Some(ans))
     }
 
-    pub fn parse(feeder: &mut Feeder, core: &mut ShellCore, addline: bool, left: &str)
-        -> Result<Option<Self>, ParseError> {
+    pub fn parse(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+        addline: bool,
+        left: &str,
+    ) -> Result<Option<Self>, ParseError> {
         let mut ans = ArithmeticExpr::new();
 
         loop {
@@ -303,7 +338,7 @@ impl ArithmeticExpr {
                 ans.elements.push(sp);
             }
 
-            if ! ans.in_ternary && feeder.starts_with(":") {
+            if !ans.in_ternary && feeder.starts_with(":") {
                 break;
             }
 
@@ -311,20 +346,21 @@ impl ArithmeticExpr {
                 break;
             }
 
-            if Self::eat_output_format(feeder, &mut ans, core) 
-            || Self::eat_ternary_symbol(feeder, &mut ans)
-            || Self::eat_unary_operator(feeder, &mut ans, core)
-            || Self::eat_paren(feeder, core, &mut ans)?
-            || Self::eat_binary_operator(feeder, &mut ans, core)
-            || Self::eat_array_elem(feeder, &mut ans, core, false)?
-            || Self::eat_word(feeder, &mut ans, core, false) { 
+            if Self::eat_output_format(feeder, &mut ans, core)
+                || Self::eat_ternary_symbol(feeder, &mut ans)
+                || Self::eat_unary_operator(feeder, &mut ans, core)
+                || Self::eat_paren(feeder, core, &mut ans)?
+                || Self::eat_binary_operator(feeder, &mut ans, core)
+                || Self::eat_array_elem(feeder, &mut ans, core, false)?
+                || Self::eat_word(feeder, &mut ans, core, false)
+            {
                 continue;
             }
 
-            if ! addline || feeder.len() != 0 || ! feeder.feed_additional_line(core).is_ok() {
+            if !addline || !feeder.is_empty() || feeder.feed_additional_line(core).is_err() {
                 break;
             }
         }
-        return Ok(Some(ans));
+        Ok(Some(ans))
     }
 }

--- a/src/elements/expr/arithmetic/rev_polish.rs
+++ b/src/elements/expr/arithmetic/rev_polish.rs
@@ -1,9 +1,9 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
+use super::elem::ArithElem;
 use crate::error::arith::ArithError;
 use crate::error::exec::ExecError;
-use super::elem::ArithElem;
 
 pub fn rearrange(elements: &[ArithElem]) -> Result<Vec<ArithElem>, ExecError> {
     let mut ans = vec![];
@@ -18,35 +18,34 @@ pub fn rearrange(elements: &[ArithElem]) -> Result<Vec<ArithElem>, ExecError> {
         prev_is_op = is_op;
 
         match is_op {
-            true  => ans.push(e.clone()),
-            false => rev_polish_op(&e, &mut stack, &mut ans),
+            true => ans.push(e.clone()),
+            false => rev_polish_op(e, &mut stack, &mut ans),
         };
     }
 
-    while stack.len() > 0 {
-        ans.push(stack.pop().unwrap());
+    while let Some(element) = stack.pop() {
+        ans.push(element);
     }
 
     Ok(ans)
 }
 
-fn rev_polish_op(elem: &ArithElem, stack: &mut Vec<ArithElem>,
-                 ans: &mut Vec<ArithElem>) {
+fn rev_polish_op(elem: &ArithElem, stack: &mut Vec<ArithElem>, ans: &mut Vec<ArithElem>) {
     loop {
         match stack.last() {
             None => {
                 stack.push(elem.clone());
                 break;
-            },
+            }
             Some(_) => {
                 let last = stack.last().unwrap();
-                if last.order() < elem.order() 
-                || (last.order() == 2 && elem.order() == 2) { // assignment
+                if last.order() < elem.order() || (last.order() == 2 && elem.order() == 2) {
+                    // assignment
                     stack.push(elem.clone());
                     break;
                 }
                 ans.push(stack.pop().unwrap());
-            },
+            }
         }
     }
 }

--- a/src/elements/expr/conditional/elem.rs
+++ b/src/elements/expr/conditional/elem.rs
@@ -1,10 +1,11 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
-use crate::elements::word::Word;
 use super::ConditionalExpr;
+use crate::elements::word::Word;
 use crate::error::exec::ExecError;
+use crate::ShellCore;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 
 #[derive(Debug, Clone)]
 pub enum CondElem {
@@ -16,7 +17,7 @@ pub enum CondElem {
     InParen(ConditionalExpr),
     Not, // !
     And, // &&
-    Or, // ||
+    Or,  // ||
     Ans(bool),
 }
 
@@ -31,18 +32,17 @@ impl CondElem {
     }
 
     pub fn eval(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
-        match self {
-            CondElem::Word(ref mut w) => {
-                let new_w = w.tilde_and_dollar_expansion(core)?;
-                *w = new_w;
-            },
-            _ => {},
+        if let CondElem::Word(ref mut w) = self {
+            let new_w = w.tilde_and_dollar_expansion(core)?;
+            *w = new_w;
         }
         Ok(())
     }
+}
 
-    pub fn to_string(&self) -> String {
-        match self {
+impl Display for CondElem {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let s = match self {
             CondElem::UnaryOp(op) => op.to_string(),
             CondElem::BinaryOp(op) => op.to_string(),
             CondElem::InParen(expr) => expr.text.clone(),
@@ -54,6 +54,7 @@ impl CondElem {
             CondElem::Or => "||".to_string(),
             CondElem::Ans(true) => "true".to_string(),
             CondElem::Ans(false) => "false".to_string(),
-        }
+        };
+        write!(f, "{s}")
     }
 }

--- a/src/elements/expr/conditional/parser.rs
+++ b/src/elements/expr/conditional/parser.rs
@@ -1,18 +1,16 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
-use crate::error::parse::ParseError;
+use super::{CondElem, ConditionalExpr};
+use crate::elements::command;
 use crate::elements::subword;
 use crate::elements::word::Word;
-use crate::elements::command;
-use super::{CondElem, ConditionalExpr};
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
 
 impl ConditionalExpr {
     fn eat_word(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> bool {
-        if feeder.starts_with("]]")
-        || feeder.starts_with(")")
-        || feeder.starts_with("(") {
+        if feeder.starts_with("]]") || feeder.starts_with(")") || feeder.starts_with("(") {
             return false;
         }
 
@@ -22,8 +20,8 @@ impl ConditionalExpr {
                 ans.elements.push(CondElem::Word(w));
 
                 true
-            },
-            _ => false
+            }
+            _ => false,
         }
     }
 
@@ -42,7 +40,7 @@ impl ConditionalExpr {
 
     fn eat_subwords(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> Word {
         let mut word = Word::default();
-        while ! feeder.starts_with(" ") {
+        while !feeder.starts_with(" ") {
             if let Ok(Some(sw)) = subword::parse(feeder, core, &None) {
                 ans.text += sw.get_text();
                 word.text += sw.get_text();
@@ -57,19 +55,19 @@ impl ConditionalExpr {
 
             let symbol = feeder.consume(len);
             ans.text += &symbol.clone();
-            word.subwords.push( From::from(&symbol) );
+            word.subwords.push(From::from(&symbol));
         }
 
         word
     }
 
     fn eat_regex(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> bool {
-        if ! Self::eat_blank(feeder, ans, core) {
+        if !Self::eat_blank(feeder, ans, core) {
             return false;
         }
 
         let w = Self::eat_subwords(feeder, ans, core);
-        ans.elements.push( CondElem::Regex(w) );
+        ans.elements.push(CondElem::Regex(w));
         true
     }
 
@@ -89,34 +87,33 @@ impl ConditionalExpr {
     fn eat_not_and_or(feeder: &mut Feeder, ans: &mut Self) -> bool {
         if feeder.starts_with("!") {
             ans.text += &feeder.consume(1);
-            ans.elements.push( CondElem::Not );
+            ans.elements.push(CondElem::Not);
             return true;
         }
         if feeder.starts_with("&&") {
             ans.text += &feeder.consume(2);
-            ans.elements.push( CondElem::And );
+            ans.elements.push(CondElem::And);
             return true;
         }
         if feeder.starts_with("||") {
             ans.text += &feeder.consume(2);
-            ans.elements.push( CondElem::Or );
+            ans.elements.push(CondElem::Or);
             return true;
         }
 
         false
     }
 
-    fn eat_paren(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> Result<bool, ParseError> {
-        if let Some(e) = ans.elements.last() {
-            match e {
-                CondElem::UnaryOp(_) => {
-                    return Ok(false)
-                },
-                _ => {},
-            }
+    fn eat_paren(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<bool, ParseError> {
+        if let Some(CondElem::UnaryOp(_)) = ans.elements.last() {
+            return Ok(false);
         }
 
-        if ! feeder.starts_with("(") {
+        if !feeder.starts_with("(") {
             return Ok(false);
         }
 
@@ -124,15 +121,15 @@ impl ConditionalExpr {
 
         let expr = match Self::parse(feeder, core)? {
             Some(e) => e,
-            None    => return Ok(false),
+            None => return Ok(false),
         };
 
-        if ! feeder.starts_with(")") {
+        if !feeder.starts_with(")") {
             return Ok(false);
         }
 
         ans.text += &expr.text.clone();
-        ans.elements.push( CondElem::InParen(expr) );
+        ans.elements.push(CondElem::InParen(expr));
         ans.text += &feeder.consume(1);
         Ok(true)
     }
@@ -143,7 +140,7 @@ impl ConditionalExpr {
             n => {
                 ans.text += &feeder.consume(n);
                 true
-            },
+            }
         }
     }
 
@@ -154,19 +151,18 @@ impl ConditionalExpr {
         loop {
             //Self::eat_blank(feeder, &mut ans, core)?;
             command::eat_blank_lines(feeder, core, &mut ans.text)?;
-            if feeder.starts_with("\n"){
+            if feeder.starts_with("\n") {
                 ans.text += &feeder.consume(1);
                 continue;
             }
-            if feeder.len() == 0 {
-                if ! feeder.feed_additional_line(core).is_ok() {
+            if feeder.is_empty() {
+                if feeder.feed_additional_line(core).is_err() {
                     return Ok(None);
                 }
                 continue;
             }
 
-            if feeder.starts_with("]]")
-            || feeder.starts_with(")") {
+            if feeder.starts_with("]]") || feeder.starts_with(")") {
                 if ans.elements.is_empty() {
                     return Ok(None);
                 }
@@ -180,20 +176,16 @@ impl ConditionalExpr {
             }
 
             match Self::eat_compare_op(feeder, &mut ans, core).as_ref() {
-                "" => {},
-                "=~" => {
-                    match Self::eat_regex(feeder, &mut ans, core) {
-                        false => return Ok(None),
-                        true  => continue,
-                    }
+                "" => {}
+                "=~" => match Self::eat_regex(feeder, &mut ans, core) {
+                    false => return Ok(None),
+                    true => continue,
                 },
                 _ => continue,
             }
- 
-            if read_option {
-                if Self::eat_file_check_option(feeder, &mut ans, core) {
-                    continue;
-                }
+
+            if read_option && Self::eat_file_check_option(feeder, &mut ans, core) {
+                continue;
             }
 
             if Self::eat_not_and_or(feeder, &mut ans) {

--- a/src/elements/io.rs
+++ b/src/elements/io.rs
@@ -4,15 +4,15 @@
 pub mod pipe;
 pub mod redirect;
 
-use std::os::unix::prelude::RawFd;
-use nix::{fcntl, unistd};
-use crate::ShellCore;
-use crate::error::exec::ExecError;
-use nix::errno::Errno;
-use crate::elements::Pipe;
 use crate::elements::io::redirect::Redirect;
+use crate::elements::Pipe;
+use crate::error::exec::ExecError;
+use crate::ShellCore;
+use nix::errno::Errno;
+use nix::{fcntl, unistd};
+use std::os::unix::prelude::RawFd;
 
-pub fn close(fd: RawFd, err_str: &str){
+pub fn close(fd: RawFd, err_str: &str) {
     if fd >= 0 {
         unistd::close(fd).expect(err_str);
     }
@@ -25,17 +25,17 @@ pub fn replace(from: RawFd, to: RawFd) -> bool {
 
     match unistd::dup2(from, to) {
         Ok(_) => {
-            close(from, &format!("sush(fatal): {}: cannot be closed", from));
+            close(from, &format!("sush(fatal): {from}: cannot be closed"));
             true
-        },
+        }
         Err(Errno::EBADF) => {
-            eprintln!("sush: {}: Bad file descriptor", to);
+            eprintln!("sush: {to}: Bad file descriptor");
             false
-        },
+        }
         Err(_) => {
             eprintln!("sush: dup2 Unknown error");
             false
-        },
+        }
     }
 }
 
@@ -55,11 +55,14 @@ pub fn backup(from: RawFd) -> RawFd {
     if fcntl::fcntl(from, fcntl::F_GETFD).is_err() {
         return from;
     }
-    fcntl::fcntl(from, fcntl::F_DUPFD_CLOEXEC(10))
-           .expect("Can't allocate fd for backup")
+    fcntl::fcntl(from, fcntl::F_DUPFD_CLOEXEC(10)).expect("Can't allocate fd for backup")
 }
 
-pub fn connect(pipe: &mut Pipe, rs: &mut Vec<Redirect>, core: &mut ShellCore) -> Result<(), ExecError> {
+pub fn connect(
+    pipe: &mut Pipe,
+    rs: &mut [Redirect],
+    core: &mut ShellCore,
+) -> Result<(), ExecError> {
     pipe.connect()?;
 
     for r in rs.iter_mut() {

--- a/src/elements/io/pipe.rs
+++ b/src/elements/io/pipe.rs
@@ -1,13 +1,13 @@
 //SPDX-FileCopyrightText: 2023 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{Feeder, ShellCore};
 use crate::elements::io;
 use crate::error::exec::ExecError;
-use std::os::fd::IntoRawFd;
-use std::os::unix::prelude::RawFd;
+use crate::{Feeder, ShellCore};
 use nix::unistd;
 use nix::unistd::Pid;
+use std::os::fd::IntoRawFd;
+use std::os::unix::prelude::RawFd;
 
 #[derive(Debug, Clone)]
 pub struct Pipe {
@@ -23,7 +23,7 @@ pub struct Pipe {
 impl Pipe {
     pub fn new(text: String) -> Pipe {
         Pipe {
-            text: text,
+            text,
             recv: -1,
             send: -1,
             prev: -1,
@@ -59,7 +59,7 @@ impl Pipe {
 
         if len > 0 {
             Some(Self::new(feeder.consume(len)))
-        }else{
+        } else {
             None
         }
     }
@@ -77,15 +77,15 @@ impl Pipe {
         io::replace(self.send, 1);
         io::replace(self.prev, 0);
 
-        if &self.text == &"|&" {
+        if self.text == "|&" {
             io::share(1, 2)?;
         }
         Ok(())
     }
 
     pub fn parent_close(&mut self) {
-            io::close(self.send, "Cannot close parent pipe out");
-            io::close(self.prev,"Cannot close parent prev pipe out");
+        io::close(self.send, "Cannot close parent pipe out");
+        io::close(self.prev, "Cannot close parent prev pipe out");
     }
 
     pub fn is_connected(&self) -> bool {

--- a/src/elements/pipeline.rs
+++ b/src/elements/pipeline.rs
@@ -1,14 +1,14 @@
 //SPDX-FileCopyrightText: 2022 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{Feeder, ShellCore};
-use crate::error::exec::ExecError;
-use crate::error::parse::ParseError;
 use super::command;
 use super::command::Command;
 use super::Pipe;
-use nix::time;
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
 use nix::sys::resource;
+use nix::time;
 use nix::time::ClockId;
 use nix::unistd::Pid;
 
@@ -22,9 +22,13 @@ pub struct Pipeline {
 }
 
 impl Pipeline {
-    pub fn exec(&mut self, core: &mut ShellCore, pgid: Pid)
-        -> (Vec<Option<Pid>>, bool, bool, Option<ExecError>) {
-        if self.commands.is_empty() { // the case of only '!'
+    pub fn exec(
+        &mut self,
+        core: &mut ShellCore,
+        pgid: Pid,
+    ) -> (Vec<Option<Pid>>, bool, bool, Option<ExecError>) {
+        if self.commands.is_empty() {
+            // the case of only '!'
             self.set_time(core);
             return (vec![], self.exclamation, self.time, None);
         }
@@ -40,16 +44,17 @@ impl Pipeline {
 
             match self.commands[i].exec(core, p) {
                 Ok(pid) => pids.push(pid),
-                Err(e)  => return (pids, self.exclamation, self.time, Some(e)),
+                Err(e) => return (pids, self.exclamation, self.time, Some(e)),
             }
 
-            if i == 0 && pgid.as_raw() == 0 { // 最初のexecが終わったら、pgidにコマンドのPIDを記録
+            if i == 0 && pgid.as_raw() == 0 {
+                // 最初のexecが終わったら、pgidにコマンドのPIDを記録
                 pgid = pids[0].unwrap();
             }
             prev = p.recv;
         }
 
-        let lastpipe = (! core.db.flags.contains('m')) && core.shopts.query("lastpipe");
+        let lastpipe = (!core.db.flags.contains('m')) && core.shopts.query("lastpipe");
         let mut lastp = Pipe::end(prev, pgid, lastpipe);
         let result = self.commands[self.pipes.len()].exec(core, &mut lastp);
         if lastpipe {
@@ -65,7 +70,7 @@ impl Pipeline {
     }
 
     fn set_time(&mut self, core: &mut ShellCore) {
-        if ! self.time {
+        if !self.time {
             return;
         }
 
@@ -77,7 +82,11 @@ impl Pipeline {
         core.measured_time.real = time::clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap();
     }
 
-    pub fn read_heredoc(&mut self, feeder: &mut Feeder, core: &mut ShellCore) -> Result<(), ParseError> {
+    pub fn read_heredoc(
+        &mut self,
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+    ) -> Result<(), ParseError> {
         for command in self.commands.iter_mut() {
             command.read_heredoc(feeder, core)?;
         }
@@ -102,11 +111,11 @@ impl Pipeline {
 
     fn eat_exclamation(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> bool {
         match feeder.starts_with("!") {
-            true  => ans.text += &feeder.consume(1),
+            true => ans.text += &feeder.consume(1),
             false => return false,
         }
 
-        ans.exclamation = ! ans.exclamation;
+        ans.exclamation = !ans.exclamation;
         let blank_len = feeder.scanner_blank(core);
         ans.text += &feeder.consume(blank_len);
         true
@@ -114,7 +123,7 @@ impl Pipeline {
 
     fn eat_time(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> bool {
         match feeder.starts_with("time") {
-            true  => ans.text += &feeder.consume(4),
+            true => ans.text += &feeder.consume(4),
             false => return false,
         }
 
@@ -124,8 +133,11 @@ impl Pipeline {
         true
     }
 
-    fn eat_command(feeder: &mut Feeder, ans: &mut Pipeline, core: &mut ShellCore)
-                   -> Result<bool, ParseError> {
+    fn eat_command(
+        feeder: &mut Feeder,
+        ans: &mut Pipeline,
+        core: &mut ShellCore,
+    ) -> Result<bool, ParseError> {
         if let Some(command) = command::parse(feeder, core)? {
             ans.text += &command.get_text();
             ans.commands.push(command);
@@ -142,7 +154,7 @@ impl Pipeline {
             ans.text += &p.text.clone();
             ans.pipes.push(p);
             true
-        }else{
+        } else {
             false
         }
     }
@@ -150,35 +162,40 @@ impl Pipeline {
     fn eat_blank_and_comment(feeder: &mut Feeder, ans: &mut Pipeline, core: &mut ShellCore) {
         loop {
             let blank_len = feeder.scanner_multiline_blank(core);
-            ans.text += &feeder.consume(blank_len);             //空白、空行を削除
+            ans.text += &feeder.consume(blank_len); //空白、空行を削除
             let comment_len = feeder.scanner_comment();
-            ans.text += &feeder.consume(comment_len);             //コメントを削除
-            if blank_len + comment_len == 0 { //空白、空行、コメントがなければ出る
+            ans.text += &feeder.consume(comment_len); //コメントを削除
+            if blank_len + comment_len == 0 {
+                //空白、空行、コメントがなければ出る
                 break;
             }
         }
     }
 
-    pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Pipeline>, ParseError> {
+    pub fn parse(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+    ) -> Result<Option<Pipeline>, ParseError> {
         let mut ans = Pipeline::default();
 
-        while Self::eat_exclamation(feeder, &mut ans, core) 
-        || Self::eat_time(feeder, &mut ans, core) { }
+        while Self::eat_exclamation(feeder, &mut ans, core)
+            || Self::eat_time(feeder, &mut ans, core)
+        {}
 
-        if ! Self::eat_command(feeder, &mut ans, core)? {
+        if !Self::eat_command(feeder, &mut ans, core)? {
             match ans.exclamation || ans.time {
-                true  => return Ok(Some(ans)),
+                true => return Ok(Some(ans)),
                 false => return Ok(None),
             }
         }
 
-        while Self::eat_pipe(feeder, &mut ans, core){
+        while Self::eat_pipe(feeder, &mut ans, core) {
             loop {
                 Self::eat_blank_and_comment(feeder, &mut ans, core);
                 if Self::eat_command(feeder, &mut ans, core)? {
                     break;
                 }
-                if feeder.len() != 0 {
+                if !feeder.is_empty() {
                     return Ok(None);
                 }
                 feeder.feed_additional_line(core)?;

--- a/src/elements/script.rs
+++ b/src/elements/script.rs
@@ -6,7 +6,7 @@ use crate::error::exec::ExecError;
 use crate::error::parse::ParseError;
 use crate::{Feeder, ShellCore};
 
-enum Status{
+enum Status {
     UnexpectedSymbol(String),
     NeedMoreLine,
     NormalEnd,
@@ -27,7 +27,9 @@ impl Script {
         Ok(())
     }
 
-    pub fn get_text(&self) -> String { self.text.clone() }
+    pub fn get_text(&self) -> String {
+        self.text.clone()
+    }
 
     pub fn pretty_print(&mut self, indent_num: usize) {
         let mut semicolon = false;
@@ -44,14 +46,14 @@ impl Script {
             if semicolon {
                 println!(";");
                 semicolon = false;
-            }else if printed {
-                println!("");
+            } else if printed {
+                println!();
             }
 
             let tmp = self.job_ends[i].clone();
             let job_end = tmp.trim_ascii_end();
 
-            let text = job_text.to_owned() + &job_end;
+            let text = job_text.to_owned() + job_end;
 
             for _ in 0..indent_num {
                 print!("    ");
@@ -59,14 +61,14 @@ impl Script {
             print!("{}", &text);
             printed = true;
         }
-        println!("");
+        println!();
     }
 
     pub fn get_one_line_text(&self) -> String {
         /*
-    pub jobs: Vec<Job>,
-    pub job_ends: Vec<String>,
-        */
+        pub jobs: Vec<Job>,
+        pub job_ends: Vec<String>,
+            */
         //self.text.replace("\n", "")
         let mut ans = String::new();
         for (i, j) in self.jobs.iter().enumerate() {
@@ -78,12 +80,16 @@ impl Script {
         ans
     }
 
-    fn eat_job(feeder: &mut Feeder, core: &mut ShellCore, ans: &mut Script) -> Result<bool, ParseError> {
+    fn eat_job(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+        ans: &mut Script,
+    ) -> Result<bool, ParseError> {
         if let Some(job) = Job::parse(feeder, core)? {
             ans.text += &job.text.clone();
             ans.jobs.push(job);
             Ok(true)
-        }else{
+        } else {
             Ok(false)
         }
     }
@@ -96,29 +102,32 @@ impl Script {
         let len = feeder.scanner_job_end();
         let end = &feeder.consume(len);
         ans.job_ends.push(end.clone());
-        ans.text += &end;
+        ans.text += end;
         len != 0
     }
 
     fn check_nest(&self, feeder: &mut Feeder, permit_empty: bool) -> Status {
         let nest = feeder.nest.last().unwrap();
 
-        if nest.0 == "" && feeder.len() == 0 {
+        if nest.0.is_empty() && feeder.is_empty() {
             return Status::NormalEnd;
         }
 
-        match ( nest.1.iter().find(|e| feeder.starts_with(e)), self.pipeline_num() ) {
-            ( Some(end), 0 ) => {
+        match (
+            nest.1.iter().find(|e| feeder.starts_with(e)),
+            self.pipeline_num(),
+        ) {
+            (Some(end), 0) => {
                 if permit_empty {
                     return Status::NormalEnd;
                 }
-                return Status::UnexpectedSymbol(end.to_string())
-            },
-            ( Some(_), _)    => return Status::NormalEnd,
-            ( None, _)       => {}, 
+                return Status::UnexpectedSymbol(end.to_string());
+            }
+            (Some(_), _) => return Status::NormalEnd,
+            (None, _) => {}
         }
 
-        if feeder.len() > 0 {
+        if !feeder.is_empty() {
             let remaining = feeder.consume(feeder.len());
             let first_token = remaining.split(" ").nth(0).unwrap().to_string();
             return Status::UnexpectedSymbol(first_token);
@@ -139,35 +148,44 @@ impl Script {
         self.jobs.iter().map(|j| j.pipelines.len()).sum()
     }
 
-    fn read_heredoc(&mut self, feeder: &mut Feeder, core: &mut ShellCore) -> Result<(), ParseError> {
+    fn read_heredoc(
+        &mut self,
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+    ) -> Result<(), ParseError> {
         for job in self.jobs.iter_mut() {
             job.read_heredoc(feeder, core)?;
         }
         Ok(())
     }
 
-    pub fn parse(feeder: &mut Feeder, core: &mut ShellCore,
-                 permit_empty: bool) -> Result<Option<Script>, ParseError> {
+    pub fn parse(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+        permit_empty: bool,
+    ) -> Result<Option<Script>, ParseError> {
         let mut ans = Self::default();
         loop {
-            while Self::eat_job(feeder, core, &mut ans)? 
-                  && Self::eat_job_end(feeder, &mut ans) {}
+            while Self::eat_job(feeder, core, &mut ans)? && Self::eat_job_end(feeder, &mut ans) {}
 
-            match ans.check_nest(feeder, permit_empty){
+            match ans.check_nest(feeder, permit_empty) {
                 Status::NormalEnd => {
                     ans.unalias(core);
                     ans.read_heredoc(feeder, core)?;
-                    return Ok(Some(ans))
-                },
+                    return Ok(Some(ans));
+                }
                 Status::NeedMoreLine => {
                     ans.read_heredoc(feeder, core)?;
                     feeder.feed_additional_line(core)?
-                },
-                Status::UnexpectedSymbol(s) => { //unexpected symbol
-                    let _ = core.db.set_param("LINENO", &feeder.lineno.to_string(), None);
+                }
+                Status::UnexpectedSymbol(s) => {
+                    //unexpected symbol
+                    let _ = core
+                        .db
+                        .set_param("LINENO", &feeder.lineno.to_string(), None);
                     core.db.exit_status = 2;
                     return Err(ParseError::UnexpectedSymbol(s));
-                },
+                }
             }
         }
     }

--- a/src/elements/substitution/array.rs
+++ b/src/elements/substitution/array.rs
@@ -1,12 +1,12 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
-use crate::elements::command;
 use super::subscript::Subscript;
+use crate::elements::command;
+use crate::elements::word::Word;
 use crate::error::exec::ExecError;
 use crate::error::parse::ParseError;
-use crate::elements::word::Word;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone, Default)]
 pub struct Array {
@@ -16,9 +16,11 @@ pub struct Array {
 }
 
 impl Array {
-    pub fn eval(&mut self, core: &mut ShellCore, as_int: bool)
-    -> Result<Vec<(Option<Subscript>, String)>, ExecError> {
-
+    pub fn eval(
+        &mut self,
+        core: &mut ShellCore,
+        as_int: bool,
+    ) -> Result<Vec<(Option<Subscript>, String)>, ExecError> {
         if let Some(c) = self.error_strings.last() {
             return Err(ExecError::SyntaxError(c.to_string()));
         }
@@ -27,41 +29,48 @@ impl Array {
 
         if as_int {
             for (s, w) in &mut self.words {
-                ans.push( (s.clone(), w.eval_as_integer(core)?) );
+                ans.push((s.clone(), w.eval_as_integer(core)?));
             }
-        }else{
+        } else {
             for (s, w) in &mut self.words {
                 for e in w.eval(core)? {
-                    ans.push( (s.clone(), e) );
+                    ans.push((s.clone(), e));
                 }
             }
         }
         Ok(ans)
     }
 
-    fn eat_word(feeder: &mut Feeder, ans: &mut Self,
-                sub: Option<Subscript>, core: &mut ShellCore) -> bool {
+    fn eat_word(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        sub: Option<Subscript>,
+        core: &mut ShellCore,
+    ) -> bool {
         if feeder.starts_with(")") {
             return false;
         }
 
         let w = match Word::parse(feeder, core, None) {
             Ok(Some(w)) => w,
-            _       => return false,
+            _ => return false,
         };
         ans.text += &w.text;
         ans.words.push((sub, w));
         true
     }
 
-    fn eat_subscript(feeder: &mut Feeder, core: &mut ShellCore, ans: &mut Self)
-    -> Result<Option<Subscript>, ParseError> {
+    fn eat_subscript(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+        ans: &mut Self,
+    ) -> Result<Option<Subscript>, ParseError> {
         if let Some(s) = Subscript::parse(feeder, core)? {
             if feeder.starts_with("=") {
                 ans.text += &s.text.clone();
                 ans.text += &feeder.consume(1);
                 return Ok(Some(s));
-            }else{
+            } else {
                 feeder.replace(0, &s.text);
             }
         }
@@ -69,12 +78,14 @@ impl Array {
     }
 
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Array>, ParseError> {
-        if ! feeder.starts_with("(") {
+        if !feeder.starts_with("(") {
             return Ok(None);
         }
 
-        let mut ans = Self::default();
-        ans.text = feeder.consume(1);
+        let mut ans = Self {
+            text: feeder.consume(1),
+            ..Default::default()
+        };
         loop {
             command::eat_blank_lines(feeder, core, &mut ans.text)?;
 
@@ -83,19 +94,18 @@ impl Array {
                 continue;
             }
 
-            if feeder.len() != 0 {
+            if !feeder.is_empty() {
                 if feeder.starts_with(")") {
                     ans.text += &feeder.consume(1);
                     break;
-                }else if feeder.starts_with("\n") {
+                } else if feeder.starts_with("\n") {
                     ans.text += &feeder.consume(1);
                 }
 
                 let len = feeder.scanner_char();
                 ans.error_strings.push(feeder.consume(len));
                 continue;
-
-            }else if ! feeder.feed_additional_line(core).is_ok() {
+            } else if feeder.feed_additional_line(core).is_err() {
                 return Ok(None);
             }
         }

--- a/src/elements/substitution/value.rs
+++ b/src/elements/substitution/value.rs
@@ -1,13 +1,13 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
-use crate::elements::word::WordMode;
-use crate::error::parse::ParseError;
-use crate::error::exec::ExecError;
-use std::collections::HashMap;
 use super::array::Array;
 use crate::elements::word::Word;
+use crate::elements::word::WordMode;
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Default)]
 pub enum ParsedDataType {
@@ -26,31 +26,45 @@ pub struct Value {
 }
 
 impl Value {
-    pub fn eval(&mut self, core: &mut ShellCore, name: &str, append: bool) -> Result<(), ExecError> {
+    pub fn eval(
+        &mut self,
+        core: &mut ShellCore,
+        name: &str,
+        append: bool,
+    ) -> Result<(), ExecError> {
         match self.value.clone() {
             ParsedDataType::Single(v) => self.eval_as_value(&v, core, name),
             ParsedDataType::Array(mut a) => self.eval_as_array(&mut a, core, name, append),
             ParsedDataType::None => {
                 self.evaluated_string = Some("".to_string());
                 Ok(())
-            },
+            }
         }
     }
 
-    fn eval_as_value(&mut self, w: &Word, core: &mut ShellCore, name: &str)
-    -> Result<(), ExecError> {
-        self.evaluated_string = match core.db.has_flag(&name, 'i') {
-            true  => Some(w.eval_as_integer(core)?),
+    fn eval_as_value(
+        &mut self,
+        w: &Word,
+        core: &mut ShellCore,
+        name: &str,
+    ) -> Result<(), ExecError> {
+        self.evaluated_string = match core.db.has_flag(name, 'i') {
+            true => Some(w.eval_as_integer(core)?),
             false => Some(w.eval_as_value(core)?),
         };
 
         Ok(())
     }
 
-    fn eval_as_array(&mut self, a: &mut Array, core: &mut ShellCore,
-                     name: &str, append: bool) -> Result<(), ExecError> {
+    fn eval_as_array(
+        &mut self,
+        a: &mut Array,
+        core: &mut ShellCore,
+        name: &str,
+        append: bool,
+    ) -> Result<(), ExecError> {
         let prev = match append {
-            true  => core.db.get_vec(&name, true)?,
+            true => core.db.get_vec(name, true)?,
             false => vec![],
         };
 
@@ -61,33 +75,35 @@ impl Value {
             i += 1;
         }
 
-        let i_flag = core.db.has_flag(&name, 'i');
+        let i_flag = core.db.has_flag(name, 'i');
         let values = a.eval(core, i_flag)?;
 
         for (s, v) in values {
             match s {
                 Some(mut sub) => {
-                    let index = match sub.eval(core, &name) {
+                    let index = match sub.eval(core, name) {
                         Ok(i) => i,
                         Err(e) => {
                             e.print(core);
                             continue;
-                        },
+                        }
                     };
-                    if core.db.is_assoc(&name) {
+                    if core.db.is_assoc(name) {
                         hash.insert(index, v);
-                    }else{
+                    } else {
                         match index.parse::<usize>() {
                             Ok(j) => i = j,
                             Err(e) => {
                                 eprintln!("{:?}", &e);
                                 continue;
-                            },
+                            }
                         }
                         hash.insert(index, v);
                     }
-                },
-                None => {hash.insert(i.to_string(), v);},
+                }
+                None => {
+                    hash.insert(i.to_string(), v);
+                }
             }
             i += 1;
         }
@@ -101,7 +117,7 @@ impl Value {
         if let Some(a) = Array::parse(feeder, core)? {
             ans.text += &a.text;
             ans.value = ParsedDataType::Array(a);
-        }else if let Ok(Some(mut w)) = Word::parse(feeder, core, None) {
+        } else if let Ok(Some(mut w)) = Word::parse(feeder, core, None) {
             w.mode = Some(WordMode::RightOfSubstitution);
             ans.text += &w.text;
             ans.value = ParsedDataType::Single(w);

--- a/src/elements/subword.rs
+++ b/src/elements/subword.rs
@@ -2,72 +2,76 @@
 //SPDX-License-Identifier: BSD-3-Clause
 
 pub mod ansi_c_quoted;
-pub mod simple;
-pub mod single_quoted;
 mod braced_param;
 mod command_sub;
+pub mod simple;
+pub mod single_quoted;
 //mod command_sub_old;
-mod escaped_char;
-mod file_input;
-mod ext_glob;
-mod double_quoted;
-pub mod parameter;
-mod varname;
 mod arithmetic;
+mod double_quoted;
+mod escaped_char;
+mod ext_glob;
+mod file_input;
 pub mod filler;
+pub mod parameter;
 mod paren;
 mod process_sub;
+mod varname;
 
-use crate::{ShellCore, Feeder};
-use crate::error::{exec::ExecError, parse::ParseError};
-use crate::elements::word::WordMode;
-use crate::utils::splitter;
 use self::ansi_c_quoted::AnsiCQuoted;
 use self::arithmetic::Arithmetic;
-use self::simple::SimpleSubword;
 use self::braced_param::BracedParam;
 use self::command_sub::CommandSubstitution;
+use self::simple::SimpleSubword;
+use crate::elements::word::WordMode;
+use crate::error::{exec::ExecError, parse::ParseError};
+use crate::utils::splitter;
+use crate::{Feeder, ShellCore};
 //use self::command_sub_old::CommandSubstitutionOld;
-use self::escaped_char::EscapedChar;
-use self::paren::EvalLetParen;
-use self::ext_glob::ExtGlob;
-use self::filler::FillerSubword;
 use self::double_quoted::DoubleQuoted;
+use self::escaped_char::EscapedChar;
+use self::ext_glob::ExtGlob;
 use self::file_input::FileInput;
-use self::single_quoted::SingleQuoted;
-use self::process_sub::ProcessSubstitution;
+use self::filler::FillerSubword;
 use self::parameter::Parameter;
+use self::paren::EvalLetParen;
+use self::process_sub::ProcessSubstitution;
+use self::single_quoted::SingleQuoted;
 use self::varname::VarName;
 use std::fmt;
 use std::fmt::Debug;
 
 impl Debug for dyn Subword {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct(&self.get_text()).finish()
+        fmt.debug_struct(self.get_text()).finish()
     }
 }
 
-impl Clone for Box::<dyn Subword> {
+impl Clone for Box<dyn Subword> {
     fn clone(&self) -> Box<dyn Subword> {
         self.boxed_clone()
     }
 }
 
-impl Default for Box::<dyn Subword> {
+impl Default for Box<dyn Subword> {
     fn default() -> Box<dyn Subword> {
-        Box::new( SimpleSubword{ text: "".to_string() } )
+        Box::new(SimpleSubword {
+            text: "".to_string(),
+        })
     }
 }
 
-impl From<&String> for Box::<dyn Subword> {
-    fn from(s: &String) -> Box::<dyn Subword> {
-        Box::new( SimpleSubword{ text: s.clone() } )
+impl From<&String> for Box<dyn Subword> {
+    fn from(s: &String) -> Box<dyn Subword> {
+        Box::new(SimpleSubword { text: s.clone() })
     }
 }
 
-impl From<&str> for Box::<dyn Subword> {
-    fn from(s: &str) -> Box::<dyn Subword> {
-        Box::new( SimpleSubword{ text: s.to_string() } )
+impl From<&str> for Box<dyn Subword> {
+    fn from(s: &str) -> Box<dyn Subword> {
+        Box::new(SimpleSubword {
+            text: s.to_string(),
+        })
     }
 }
 
@@ -75,35 +79,54 @@ pub trait Subword {
     fn get_text(&self) -> &str;
     fn set_text(&mut self, _: &str) {}
     fn boxed_clone(&self) -> Box<dyn Subword>;
-    fn substitute(&mut self, _: &mut ShellCore) -> Result<(), ExecError> { Ok(()) }
-    fn alter(&mut self) -> Result<Vec<Box<dyn Subword>>, ExecError> { Ok(vec![]) }
-
-    fn split(&self, ifs: &str, prev_char: Option<char>) -> Vec<(Box<dyn Subword>, bool)>{ //bool: true if it should remain
-        splitter::split(&self.get_text(), ifs, prev_char).iter()
-            .map(|s| ( From::from(&s.0), s.1)).collect()
+    fn substitute(&mut self, _: &mut ShellCore) -> Result<(), ExecError> {
+        Ok(())
+    }
+    fn alter(&mut self) -> Result<Vec<Box<dyn Subword>>, ExecError> {
+        Ok(vec![])
     }
 
-    fn make_glob_string(&mut self) -> String {self.get_text().to_string()}
+    fn split(&self, ifs: &str, prev_char: Option<char>) -> Vec<(Box<dyn Subword>, bool)> {
+        //bool: true if it should remain
+        splitter::split(self.get_text(), ifs, prev_char)
+            .iter()
+            .map(|s| (From::from(&s.0), s.1))
+            .collect()
+    }
+
+    fn make_glob_string(&mut self) -> String {
+        self.get_text().to_string()
+    }
 
     fn make_unquoted_string(&mut self) -> Option<String> {
         match self.get_text() {
             "" => None,
-            s  => Some(s.to_string()),
+            s => Some(s.to_string()),
         }
     }
 
     fn make_regex(&mut self) -> Option<String> {
         match self.get_text() {
             "" => None,
-            s  => Some(s.to_string()),
+            s => Some(s.to_string()),
         }
     }
 
-    fn is_name(&self) -> bool {false}
-    fn is_array(&self) -> bool {false}
-    fn get_elem(&self) -> Vec<String> {vec![]}
-    fn is_extglob(&self) -> bool {false}
-    fn get_child_subwords(&self) -> Vec<Box<dyn Subword>> { vec![] }
+    fn is_name(&self) -> bool {
+        false
+    }
+    fn is_array(&self) -> bool {
+        false
+    }
+    fn get_elem(&self) -> Vec<String> {
+        vec![]
+    }
+    fn is_extglob(&self) -> bool {
+        false
+    }
+    fn get_child_subwords(&self) -> Vec<Box<dyn Subword>> {
+        vec![]
+    }
     fn set_heredoc_flag(&mut self) {}
 }
 
@@ -123,7 +146,7 @@ fn replace_history_expansion(feeder: &mut Feeder, core: &mut ShellCore) -> bool 
     for h in &core.history[1..] {
         let last = h.split(" ").last().unwrap();
 
-        if ! last.starts_with("!$") {
+        if !last.starts_with("!$") {
             his = last.to_string();
             break;
         }
@@ -133,61 +156,85 @@ fn replace_history_expansion(feeder: &mut Feeder, core: &mut ShellCore) -> bool 
     true
 }
 
-pub fn parse_special_subword(feeder: &mut Feeder,core: &mut ShellCore,
-    mode: &Option<WordMode>) -> Result<Option<Box<dyn Subword>>, ParseError> {
+pub fn parse_special_subword(
+    feeder: &mut Feeder,
+    core: &mut ShellCore,
+    mode: &Option<WordMode>,
+) -> Result<Option<Box<dyn Subword>>, ParseError> {
     match mode {
         None => Ok(None),
         Some(WordMode::ParamOption(ref v)) => {
-            if feeder.len() == 0 || feeder.starts_withs2(v) {
+            if feeder.is_empty() || feeder.starts_withs2(v) {
                 return Ok(None);
             }
 
             let len = feeder.scanner_char();
-            let c = FillerSubword { text: feeder.consume(len) };
-            if feeder.len() == 0 {
+            let c = FillerSubword {
+                text: feeder.consume(len),
+            };
+            if feeder.is_empty() {
                 feeder.feed_additional_line(core)?;
             }
             Ok(Some(Box::new(c)))
-        },
+        }
         Some(WordMode::ReadCommand) => {
-            if feeder.len() == 0 
-            || feeder.starts_withs(&["\n", "\t", " "]) {
+            if feeder.is_empty() || feeder.starts_withs(&["\n", "\t", " "]) {
                 Ok(None)
-            }else{
+            } else {
                 Ok(Some(From::from(&feeder.consume(1))))
             }
-        },
+        }
         Some(WordMode::Alias) => {
             if feeder.starts_with("\t") {
                 Ok(Some(From::from(&feeder.consume(1))))
-            }else{
+            } else {
                 Ok(None)
             }
-        },
+        }
         _ => Ok(None),
     }
 }
 
-pub fn parse(feeder: &mut Feeder, core: &mut ShellCore,
-             mode: &Option<WordMode>) -> Result<Option<Box<dyn Subword>>, ParseError> {
+pub fn parse(
+    feeder: &mut Feeder,
+    core: &mut ShellCore,
+    mode: &Option<WordMode>,
+) -> Result<Option<Box<dyn Subword>>, ParseError> {
     if replace_history_expansion(feeder, core) {
         return parse(feeder, core, mode);
     }
 
-    if let Some(a) = BracedParam::parse(feeder, core)?{ Ok(Some(Box::new(a))) }
-    else if let Some(a) = AnsiCQuoted::parse(feeder, core)?{ Ok(Some(Box::new(a))) }
-    else if let Some(a) = Arithmetic::parse(feeder, core)?{ Ok(Some(Box::new(a))) }
-    else if let Some(a) = FileInput::parse(feeder, core)?{ Ok(Some(Box::new(a))) }
-    else if let Some(a) = CommandSubstitution::parse(feeder, core)?{ Ok(Some(Box::new(a))) }
+    if let Some(a) = BracedParam::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = AnsiCQuoted::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = Arithmetic::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = FileInput::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = CommandSubstitution::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    }
     //else if let Some(a) = CommandSubstitutionOld::parse(feeder, core)?{ Ok(Some(Box::new(a))) }
-    else if let Some(a) = ProcessSubstitution::parse(feeder, core, mode)?{ Ok(Some(Box::new(a))) }
-    else if let Some(a) = SingleQuoted::parse(feeder, core){ Ok(Some(Box::new(a))) }
-    else if let Some(a) = DoubleQuoted::parse(feeder, core, mode)? { Ok(Some(Box::new(a))) }
-    else if let Some(a) = ExtGlob::parse(feeder, core)? { Ok(Some(Box::new(a))) }
-    else if let Some(a) = EscapedChar::parse(feeder, core){ Ok(Some(Box::new(a))) }
-    else if let Some(a) = Parameter::parse(feeder, core){ Ok(Some(Box::new(a))) }
-    else if let Some(a) = VarName::parse(feeder, core){ Ok(Some(Box::new(a))) }
-    else if let Some(a) = SimpleSubword::parse(feeder){ Ok(Some(Box::new(a))) }
-    else if let Some(a) = EvalLetParen::parse(feeder, core, mode)?{ Ok(Some(Box::new(a))) }
-    else{ parse_special_subword(feeder, core, mode) }
+    else if let Some(a) = ProcessSubstitution::parse(feeder, core, mode)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = SingleQuoted::parse(feeder, core) {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = DoubleQuoted::parse(feeder, core, mode)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = ExtGlob::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = EscapedChar::parse(feeder, core) {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = Parameter::parse(feeder, core) {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = VarName::parse(feeder, core) {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = SimpleSubword::parse(feeder) {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = EvalLetParen::parse(feeder, core, mode)? {
+        Ok(Some(Box::new(a)))
+    } else {
+        parse_special_subword(feeder, core, mode)
+    }
 }

--- a/src/elements/subword/ansi_c_quoted.rs
+++ b/src/elements/subword/ansi_c_quoted.rs
@@ -1,9 +1,9 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
+use super::{EscapedChar, SimpleSubword, Subword};
 use crate::error::parse::ParseError;
-use super::{Subword, SimpleSubword, EscapedChar};
+use crate::{Feeder, ShellCore};
 
 #[derive(Clone, Debug)]
 enum Token {
@@ -18,25 +18,25 @@ enum Token {
 }
 
 impl Token {
-    fn to_string(&mut self, compat_bash: bool) -> String {
+    fn to_string(&self, compat_bash: bool) -> String {
         match &self {
             Token::EmptyHex => String::new(),
-            Token::Normal(s) => s.clone(), 
+            Token::Normal(s) => s.clone(),
             Token::Oct(s) => {
-                let mut num = u32::from_str_radix(&s, 8).unwrap();
+                let mut num = u32::from_str_radix(s, 8).unwrap();
                 if num >= 256 {
                     num -= 256;
                 }
 
                 if compat_bash {
-                    unsafe{ String::from_utf8_unchecked(vec![num.try_into().unwrap()]) }
-                }else{
+                    unsafe { String::from_utf8_unchecked(vec![num.try_into().unwrap()]) }
+                } else {
                     char::from(num as u8).to_string()
                 }
-            },
+            }
             Token::Hex(s) => {
                 let hex = match s.len() > 2 {
-                    true  => s[s.len()-2..].to_string(),
+                    true => s[s.len() - 2..].to_string(),
                     false => s.to_string(),
                 };
 
@@ -49,41 +49,54 @@ impl Token {
                 }
 
                 if compat_bash {
-                    unsafe{ String::from_utf8_unchecked(vec![num.try_into().unwrap()]) }
-                }else{
+                    unsafe { String::from_utf8_unchecked(vec![num.try_into().unwrap()]) }
+                } else {
                     char::from(num as u8).to_string()
                 }
-            },
+            }
             Token::Unicode4(s) => {
-                let num = u32::from_str_radix(&s, 16).unwrap();
+                let num = u32::from_str_radix(s, 16).unwrap();
                 match char::from_u32(num) {
                     Some(c) => c.to_string(),
                     _ => "U+".to_owned() + s,
                 }
-            },
+            }
             Token::Unicode8(s) => {
-                let num = u64::from_str_radix(&s, 16).unwrap();
+                let num = u64::from_str_radix(s, 16).unwrap();
                 unsafe { char::from_u32_unchecked(num as u32) }.to_string()
-            },
+            }
             Token::Control(c) => {
-                let num = if *c == '@' { 0 }
-                    else if *c == '[' { 27 }
-                    else if *c == '\\' { 28 }
-                    else if *c == ']' { 29 }
-                    else if *c == '^' { 30 }
-                    else if *c == '_' { 31 }
-                    else if *c == '?' { 127 }
-                    else if '0' <= *c && *c <= '9' { *c as u32 - 32 }
-                    else if 'a' <= *c && *c <= 'z' { *c as u32 - 96 }
-                    else if 'A' <= *c && *c <= 'Z' { *c as u32 - 64 }
-                    else if *c as u32 >= 32 { *c as u32 - 32 }
-                    else{ *c as u32 };
+                let num = if *c == '@' {
+                    0
+                } else if *c == '[' {
+                    27
+                } else if *c == '\\' {
+                    28
+                } else if *c == ']' {
+                    29
+                } else if *c == '^' {
+                    30
+                } else if *c == '_' {
+                    31
+                } else if *c == '?' {
+                    127
+                } else if '0' <= *c && *c <= '9' {
+                    *c as u32 - 32
+                } else if 'a' <= *c && *c <= 'z' {
+                    *c as u32 - 96
+                } else if 'A' <= *c && *c <= 'Z' {
+                    *c as u32 - 64
+                } else if *c as u32 >= 32 {
+                    *c as u32 - 32
+                } else {
+                    *c as u32
+                };
 
                 char::from_u32(num).unwrap().to_string()
-            },
+            }
             Token::OtherEscaped(s) => match s.as_ref() {
                 "a" => char::from(7).to_string(),
-                "b" =>  char::from(8).to_string(),
+                "b" => char::from(8).to_string(),
                 "e" | "E" => char::from(27).to_string(),
                 "f" => char::from(12).to_string(),
                 "n" => "\n".to_string(),
@@ -94,7 +107,7 @@ impl Token {
                 "'" => "'".to_string(),
                 "\"" => "\"".to_string(),
                 _ => ("\\".to_owned() + s).to_string(),
-            }
+            },
         }
     }
 }
@@ -103,15 +116,21 @@ impl Token {
 pub struct AnsiCQuoted {
     text: String,
     tokens: Vec<Token>,
-    in_heredoc: bool, 
+    in_heredoc: bool,
     compat_bash: bool,
 }
 
 impl Subword for AnsiCQuoted {
-    fn get_text(&self) -> &str {&self.text}
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
+    fn get_text(&self) -> &str {
+        &self.text
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
 
-    fn make_unquoted_string(&mut self) -> Option<String> { Some(self.make_glob_string()) }
+    fn make_unquoted_string(&mut self) -> Option<String> {
+        Some(self.make_glob_string())
+    }
 
     fn make_glob_string(&mut self) -> String {
         if self.in_heredoc {
@@ -129,9 +148,13 @@ impl Subword for AnsiCQuoted {
         ans
     }
 
-    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)>{ vec![] }
+    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)> {
+        vec![]
+    }
 
-    fn set_heredoc_flag(&mut self) {self.in_heredoc = true; }
+    fn set_heredoc_flag(&mut self) {
+        self.in_heredoc = true;
+    }
 }
 
 impl AnsiCQuoted {
@@ -140,7 +163,7 @@ impl AnsiCQuoted {
             ans.text += a.get_text();
             ans.tokens.push(Token::Normal(a.get_text().to_string()));
             true
-        }else{
+        } else {
             false
         }
     }
@@ -157,12 +180,12 @@ impl AnsiCQuoted {
 
         let token = feeder.consume(len);
         ans.text += &token.clone();
-        ans.tokens.push( Token::Oct(token[1..].to_string()));
+        ans.tokens.push(Token::Oct(token[1..].to_string()));
         true
     }
 
     fn eat_hex_braced(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> bool {
-        if ! feeder.starts_with("\\x{") {
+        if !feeder.starts_with("\\x{") {
             return false;
         }
 
@@ -181,10 +204,9 @@ impl AnsiCQuoted {
         ans.text += &token.clone();
         token.retain(|c| c != '}' && c != '{');
         if token.len() > 3 {
-            ans.tokens.push( Token::Hex(token[3..].to_string()));
+            ans.tokens.push(Token::Hex(token[3..].to_string()));
         }
         true
-
     }
 
     fn eat_hex(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> bool {
@@ -199,7 +221,7 @@ impl AnsiCQuoted {
 
         let token = feeder.consume(len);
         ans.text += &token.clone();
-        ans.tokens.push( Token::Hex(token[2..].to_string()));
+        ans.tokens.push(Token::Hex(token[2..].to_string()));
         true
     }
 
@@ -215,7 +237,7 @@ impl AnsiCQuoted {
 
         let token = feeder.consume(len);
         ans.text += &token.clone();
-        ans.tokens.push( Token::Unicode4(token[2..].to_string()));
+        ans.tokens.push(Token::Unicode4(token[2..].to_string()));
         true
     }
 
@@ -231,7 +253,7 @@ impl AnsiCQuoted {
 
         let token = feeder.consume(len);
         ans.text += &token.clone();
-        ans.tokens.push( Token::Unicode8(token[2..].to_string()));
+        ans.tokens.push(Token::Unicode8(token[2..].to_string()));
         true
     }
 
@@ -240,53 +262,54 @@ impl AnsiCQuoted {
             let txt = a.get_text().to_string();
             ans.text += &txt.clone();
 
-            if txt != "\\c" || feeder.len() == 0 {
+            if txt != "\\c" || feeder.is_empty() {
                 ans.tokens.push(Token::OtherEscaped(txt[1..].to_string()));
-            }else{
-                if let Some(a) = EscapedChar::parse(feeder, core) {
-                    let mut text_after = a.get_text().to_string();
-                    ans.text += &text_after.clone();
-                    text_after.remove(0);
-                    let ctrl_c = text_after.chars().nth(0).unwrap();
-                    ans.tokens.push(Token::Control(ctrl_c));
-                }else if feeder.starts_with("'") {
-                    ans.tokens.push(Token::Normal("\\c".to_string()));
-                }else{
-                    let ctrl_c = feeder.consume(1).chars().nth(0).unwrap();
-                    ans.text += &ctrl_c.to_string();
-                    ans.tokens.push(Token::Control(ctrl_c));
-                }
+            } else if let Some(a) = EscapedChar::parse(feeder, core) {
+                let mut text_after = a.get_text().to_string();
+                ans.text += &text_after.clone();
+                text_after.remove(0);
+                let ctrl_c = text_after.chars().nth(0).unwrap();
+                ans.tokens.push(Token::Control(ctrl_c));
+            } else if feeder.starts_with("'") {
+                ans.tokens.push(Token::Normal("\\c".to_string()));
+            } else {
+                let ctrl_c = feeder.consume(1).chars().nth(0).unwrap();
+                ans.text += &ctrl_c.to_string();
+                ans.tokens.push(Token::Control(ctrl_c));
             }
             true
-        }else{
+        } else {
             false
         }
     }
 
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Self>, ParseError> {
-        if ! feeder.starts_with("$'") {
+        if !feeder.starts_with("$'") {
             return Ok(None);
         }
-        let mut ans = Self::default();
-        ans.compat_bash = core.compat_bash;
+        let mut ans = Self {
+            compat_bash: core.compat_bash,
+            ..Default::default()
+        };
         ans.text += &feeder.consume(2);
 
-        while ! feeder.starts_with("'") {
-            if Self::eat_simple_subword(feeder, &mut ans) 
-            || Self::eat_hex_braced(feeder, &mut ans, core)
-            || Self::eat_hex(feeder, &mut ans, core)
-            || Self::eat_oct(feeder, &mut ans, core)
-            || Self::eat_unicode4(feeder, &mut ans, core)
-            || Self::eat_unicode8(feeder, &mut ans, core)
-            || Self::eat_escaped_char(feeder, &mut ans, core) {
+        while !feeder.starts_with("'") {
+            if Self::eat_simple_subword(feeder, &mut ans)
+                || Self::eat_hex_braced(feeder, &mut ans, core)
+                || Self::eat_hex(feeder, &mut ans, core)
+                || Self::eat_oct(feeder, &mut ans, core)
+                || Self::eat_unicode4(feeder, &mut ans, core)
+                || Self::eat_unicode8(feeder, &mut ans, core)
+                || Self::eat_escaped_char(feeder, &mut ans, core)
+            {
                 continue;
             }
 
-            if feeder.len() == 0 {
+            if feeder.is_empty() {
                 feeder.feed_additional_line(core)?;
                 continue;
             }
-        
+
             let other = feeder.consume(1);
             ans.text += &other.clone();
             ans.tokens.push(Token::Normal(other));

--- a/src/elements/subword/arithmetic.rs
+++ b/src/elements/subword/arithmetic.rs
@@ -1,11 +1,11 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
-use crate::error::exec::ExecError;
-use crate::error::parse::ParseError;
 use crate::elements::command::arithmetic::ArithmeticCommand;
 use crate::elements::subword::Subword;
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone)]
 pub struct Arithmetic {
@@ -14,8 +14,12 @@ pub struct Arithmetic {
 }
 
 impl Subword for Arithmetic {
-    fn get_text(&self) -> &str { &self.text.as_ref() }
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
 
     fn substitute(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
         self.text = self.com.eval(core)?;
@@ -25,7 +29,7 @@ impl Subword for Arithmetic {
 
 impl Arithmetic {
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Self>, ParseError> {
-        if ! feeder.starts_with("$((") {
+        if !feeder.starts_with("$((") {
             return Ok(None);
         }
         feeder.set_backup();
@@ -33,7 +37,10 @@ impl Arithmetic {
 
         if let Some(a) = ArithmeticCommand::parse(feeder, core)? {
             feeder.pop_backup();
-            return Ok(Some(Arithmetic{ text: dl + &a.text.clone(), com: a}));
+            return Ok(Some(Arithmetic {
+                text: dl + &a.text.clone(),
+                com: a,
+            }));
         }
         feeder.rewind();
         Ok(None)

--- a/src/elements/subword/braced_param.rs
+++ b/src/elements/subword/braced_param.rs
@@ -4,13 +4,13 @@
 mod optional_operation;
 mod parse;
 
-use crate::{Feeder, ShellCore};
-use crate::elements::subword::Subword;
+use self::optional_operation::OptionalOperation;
 use crate::elements::substitution::variable::Variable;
+use crate::elements::subword::Subword;
+use crate::error::exec::ExecError;
 use crate::utils;
 use crate::utils::splitter;
-use crate::error::exec::ExecError;
-use self::optional_operation::OptionalOperation;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone, Default)]
 pub struct BracedParam {
@@ -25,13 +25,18 @@ pub struct BracedParam {
 }
 
 impl Subword for BracedParam {
-    fn get_text(&self) -> &str { &self.text.as_ref() }
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
 
     fn substitute(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
         self.check()?;
 
-        if self.indirect && self.param.is_var_array() { // ${!name[@]}, ${!name[*]}
+        if self.indirect && self.param.is_var_array() {
+            // ${!name[@]}, ${!name[*]}
             self.index_replace(core)?;
             return Ok(());
         }
@@ -48,7 +53,8 @@ impl Subword for BracedParam {
                     s.set_array(&self.param, &mut arr, &mut self.text, core)?;
                     self.array = Some(arr);
                     if self.param.index.is_some()
-                    && self.param.index.as_ref().unwrap().text == "[*]" {
+                        && self.param.index.as_ref().unwrap().text == "[*]"
+                    {
                         self.text = self.array.clone().unwrap().join(&core.db.get_ifs_head());
                         self.array = None;
                     }
@@ -59,56 +65,64 @@ impl Subword for BracedParam {
         }
 
         match self.param.index.is_some() {
-            true  => self.subscript_operation(core),
+            true => self.subscript_operation(core),
             false => self.non_subscript_operation(core),
         }
     }
 
-    fn set_text(&mut self, text: &str) { self.text = text.to_string(); }
+    fn set_text(&mut self, text: &str) {
+        self.text = text.to_string();
+    }
 
-    fn is_array(&self) -> bool {self.treat_as_array }
-    fn get_elem(&self) -> Vec<String> {self.array.clone().unwrap_or_default()}
+    fn is_array(&self) -> bool {
+        self.treat_as_array
+    }
+    fn get_elem(&self) -> Vec<String> {
+        self.array.clone().unwrap_or_default()
+    }
 
     fn alter(&mut self) -> Result<Vec<Box<dyn Subword>>, ExecError> {
         match self.optional_operation.as_mut() {
             Some(op) => Ok(op.get_alternative()),
-            None     => Ok(vec![]),
+            None => Ok(vec![]),
         }
     }
 
-    fn split(&self, ifs: &str, prev_char: Option<char>) -> Vec<(Box<dyn Subword>, bool)>{ 
-        if self.text == "" {
+    fn split(&self, ifs: &str, prev_char: Option<char>) -> Vec<(Box<dyn Subword>, bool)> {
+        if self.text.is_empty() {
             return vec![];
         }
 
-        let index_is_asterisk = self.param.index.is_some()
-                                && self.param.index.as_ref().unwrap().text == "[*]";
+        let index_is_asterisk =
+            self.param.index.is_some() && self.param.index.as_ref().unwrap().text == "[*]";
 
-        if ifs == "" && ( self.param.name == "*" || index_is_asterisk ) {
+        if ifs.is_empty() && (self.param.name == "*" || index_is_asterisk) {
             return self.make_split();
         }
 
-        if ! self.treat_as_array || ifs.starts_with(" ") || self.array.is_none() {
-            return splitter::split(&self.text, ifs, prev_char).iter()
-                .map(|s| ( From::from(&s.0), s.1)).collect();
+        if !self.treat_as_array || ifs.starts_with(" ") || self.array.is_none() {
+            return splitter::split(&self.text, ifs, prev_char)
+                .iter()
+                .map(|s| (From::from(&s.0), s.1))
+                .collect();
         }
 
         self.make_split()
     }
 
     fn set_heredoc_flag(&mut self) {
-        self.optional_operation.iter_mut()
+        self.optional_operation
+            .iter_mut()
             .for_each(|e| e.set_heredoc_flag());
     }
 }
 
 impl BracedParam {
     fn check(&mut self) -> Result<(), ExecError> {
-        if self.param.name.is_empty() || ! utils::is_param(&self.param.name) {
+        if self.param.name.is_empty() || !utils::is_param(&self.param.name) {
             return Err(ExecError::BadSubstitution(self.text.clone()));
         }
-        if self.unknown.len() > 0 
-        && ! self.unknown.starts_with(",") {
+        if !self.unknown.is_empty() && !self.unknown.starts_with(",") {
             return Err(ExecError::BadSubstitution(self.text.clone()));
         }
 
@@ -118,10 +132,10 @@ impl BracedParam {
         Ok(())
     }
 
-    fn make_split(&self)-> Vec<(Box<dyn Subword>, bool)>{ 
+    fn make_split(&self) -> Vec<(Box<dyn Subword>, bool)> {
         let mut ans = vec![];
         for p in self.array.clone().unwrap() {
-            ans.push( (From::from(&p), true) );
+            ans.push((From::from(&p), true));
         }
         ans
     }
@@ -132,12 +146,12 @@ impl BracedParam {
             return Err(ExecError::InvalidName(msg));
         }
 
-        if ! core.db.has_value(&self.param.name) {
+        if !core.db.has_value(&self.param.name) {
             self.text = "".to_string();
             return Ok(());
         }
 
-        if ! core.db.is_array(&self.param.name) && ! core.db.is_assoc(&self.param.name) {
+        if !core.db.is_array(&self.param.name) && !core.db.is_assoc(&self.param.name) {
             self.text = "0".to_string();
             return Ok(());
         }
@@ -159,42 +173,47 @@ impl BracedParam {
         sw.substitute(core)?;
 
         if sw.text.contains('[') {
-            let mut feeder = Feeder::new(&("${".to_owned() + &sw.text + "}" ));
+            let mut feeder = Feeder::new(&("${".to_owned() + &sw.text + "}"));
             if let Ok(Some(mut bp)) = BracedParam::parse(&mut feeder, core) {
                 bp.substitute(core)?;
                 self.param.name = bp.param.name;
                 self.param.index = bp.param.index;
-            }else{
+            } else {
                 return Err(ExecError::InvalidName(sw.text.clone()));
             }
-        }else{
+        } else {
             self.param.name = sw.text.clone();
             self.param.index = None;
         }
 
-        if ! utils::is_param(&self.param.name) {
+        if !utils::is_param(&self.param.name) {
             return Err(ExecError::InvalidName(self.param.name.clone()));
         }
         Ok(())
     }
 
     fn non_subscript_operation(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
-            if self.param.name == "*" || self.param.name == "@" {
-                self.array = Some(core.db.get_position_params());
-            }
+        if self.param.name == "*" || self.param.name == "@" {
+            self.array = Some(core.db.get_position_params());
+        }
 
-            let value = core.db.get_param(&self.param.name).unwrap_or_default();
-            self.text = match self.num {
-                true  => core.db.get_len(&self.param.name)?.to_string(),//value.chars().count().to_string(),
-                false => value.to_string(),
-            };
-    
-            self.text = self.optional_operation(self.text.clone(), core)?;
-            Ok(())
+        let value = core.db.get_param(&self.param.name).unwrap_or_default();
+        self.text = match self.num {
+            true => core.db.get_len(&self.param.name)?.to_string(), //value.chars().count().to_string(),
+            false => value.to_string(),
+        };
+
+        self.text = self.optional_operation(self.text.clone(), core)?;
+        Ok(())
     }
 
     fn subscript_operation(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
-        let index = self.param.index.clone().unwrap().eval(core, &self.param.name)?;
+        let index = self
+            .param
+            .index
+            .clone()
+            .unwrap()
+            .eval(core, &self.param.name)?;
 
         if self.num {
             self.text = core.db.get_elem_len(&self.param.name, &index)?.to_string();
@@ -203,9 +222,10 @@ impl BracedParam {
 
         if core.db.is_single(&self.param.name) {
             let param = core.db.get_param(&self.param.name)?;
-            let tmp = match index.as_str() { //case: a=aaa; echo ${a[@]}; (output: aaa)
-                "@" | "*" | "0" => param,//.unwrap_or("".to_string()),
-                 _ => "".to_string(),
+            let tmp = match index.as_str() {
+                //case: a=aaa; echo ${a[@]}; (output: aaa)
+                "@" | "*" | "0" => param, //.unwrap_or("".to_string()),
+                _ => "".to_string(),
             };
             self.text = self.optional_operation(tmp, core)?;
             return Ok(());
@@ -216,10 +236,12 @@ impl BracedParam {
 
         if index.as_str() == "@" {
             self.atmark_operation(core, " ")
-        }else if/* ifs == "" &&*/ index.as_str() == "*" {
+        } else if
+        /* ifs == "" &&*/
+        index.as_str() == "*" {
             self.atmark_operation(core, &ifs)
             //self.atmark_operation(core, "")
-        }else{
+        } else {
             let tmp = core.db.get_elem(&self.param.name, &index)?;
             self.text = self.optional_operation(tmp, core)?;
             Ok(())
@@ -235,22 +257,22 @@ impl BracedParam {
         }
 
         self.text = match self.num {
-            true  => core.db.len(&self.param.name).to_string(),
+            true => core.db.len(&self.param.name).to_string(),
             false => core.db.get_elem(&self.param.name, "@").unwrap(),
         };
 
         if arr.len() <= 1 || self.has_value_check() {
             self.text = self.optional_operation(self.text.clone(), core)?;
-        }else {
-            for i in 0..arr.len() {
-                arr[i] = self.optional_operation(arr[i].clone(), core)?;
+        } else {
+            for item in arr.iter_mut() {
+                *item = self.optional_operation(item.clone(), core)?;
             }
             self.text = arr.join(ifs);
             self.array = Some(arr);
         }
         Ok(())
     }
-    
+
     fn has_value_check(&mut self) -> bool {
         match self.optional_operation.as_mut() {
             Some(op) => op.is_value_check(),
@@ -258,7 +280,11 @@ impl BracedParam {
         }
     }
 
-    fn optional_operation(&mut self, text: String, core: &mut ShellCore) -> Result<String, ExecError> {
+    fn optional_operation(
+        &mut self,
+        text: String,
+        core: &mut ShellCore,
+    ) -> Result<String, ExecError> {
         match self.optional_operation.as_mut() {
             Some(op) => op.exec(&self.param, &text, core),
             None => Ok(text.clone()),

--- a/src/elements/subword/braced_param/optional_operation.rs
+++ b/src/elements/subword/braced_param/optional_operation.rs
@@ -2,49 +2,70 @@
 //SPDX-License-Identifier: BSD-3-Clause
 
 mod case_conv;
-mod replace;
 mod remove;
+mod replace;
 mod substr;
 mod value_check;
 
-use crate::{Feeder, ShellCore};
-use crate::error::parse::ParseError;
-use crate::elements::subword::Subword;
-use crate::error::exec::ExecError;
-use super::Variable;
 use self::case_conv::CaseConv;
-use self::replace::Replace;
 use self::remove::Remove;
+use self::replace::Replace;
 use self::substr::Substr;
 use self::value_check::ValueCheck;
+use super::Variable;
+use crate::elements::subword::Subword;
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
 use core::fmt;
 use core::fmt::Debug;
 
 pub trait OptionalOperation {
-    fn exec(&mut self, _: &Variable, _: &String, _: &mut ShellCore) -> Result<String, ExecError>;
+    fn exec(&mut self, _: &Variable, _: &str, _: &mut ShellCore) -> Result<String, ExecError>;
     fn boxed_clone(&self) -> Box<dyn OptionalOperation>;
     fn get_text(&self) -> String;
-    fn has_array_replace(&self) -> bool {false}
-    fn is_value_check(&self) -> bool {false}
-    fn set_array(&mut self, _: &Variable, _: &mut Vec<String>,
-                 _: &mut String, _: &mut ShellCore) -> Result<(), ExecError> {
+    fn has_array_replace(&self) -> bool {
+        false
+    }
+    fn is_value_check(&self) -> bool {
+        false
+    }
+    fn set_array(
+        &mut self,
+        _: &Variable,
+        _: &mut Vec<String>,
+        _: &mut String,
+        _: &mut ShellCore,
+    ) -> Result<(), ExecError> {
         Ok(())
     }
-    fn get_alternative(&self) -> Vec<Box<dyn Subword>> { vec![] }
+    fn get_alternative(&self) -> Vec<Box<dyn Subword>> {
+        vec![]
+    }
 
     fn set_heredoc_flag(&mut self) {}
 }
 
-pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Box<dyn OptionalOperation>>, ParseError> {
-    if let Some(a) = Replace::parse(feeder, core)?{ Ok(Some(Box::new(a))) }
-    else if let Some(a) = ValueCheck::parse(feeder, core)?{ Ok(Some(Box::new(a))) }
-    else if let Some(a) = CaseConv::parse(feeder, core)?{ Ok(Some(Box::new(a))) }
-    else if let Some(a) = Remove::parse(feeder, core)?{ Ok(Some(Box::new(a))) }
-    else if let Some(a) = Substr::parse(feeder, core){ Ok(Some(Box::new(a))) }
-    else{ Ok(None) }
+pub fn parse(
+    feeder: &mut Feeder,
+    core: &mut ShellCore,
+) -> Result<Option<Box<dyn OptionalOperation>>, ParseError> {
+    if let Some(a) = Replace::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = ValueCheck::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = CaseConv::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = Remove::parse(feeder, core)? {
+        Ok(Some(Box::new(a)))
+    } else if let Some(a) = Substr::parse(feeder, core) {
+        Ok(Some(Box::new(a)))
+    } else {
+        Ok(None)
+    }
 }
 
-impl Clone for Box::<dyn OptionalOperation> {
+impl Clone for Box<dyn OptionalOperation> {
     fn clone(&self) -> Box<dyn OptionalOperation> {
         self.boxed_clone()
     }

--- a/src/elements/subword/braced_param/optional_operation/case_conv.rs
+++ b/src/elements/subword/braced_param/optional_operation/case_conv.rs
@@ -1,22 +1,31 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{Feeder, ShellCore};
+use super::super::Variable;
+use super::OptionalOperation;
 use crate::elements::word::{Word, WordMode};
 use crate::error::exec::ExecError;
 use crate::error::parse::ParseError;
 use crate::utils::glob;
 use crate::utils::glob::GlobElem;
-use super::super::Variable;
-use super::OptionalOperation;
+use crate::{Feeder, ShellCore};
 
 impl OptionalOperation for CaseConv {
-    fn get_text(&self) -> String {self.text.clone()}
-    fn exec(&mut self, _: &Variable, text: &String, core: &mut ShellCore) -> Result<String, ExecError> {
+    fn get_text(&self) -> String {
+        self.text.clone()
+    }
+    fn exec(
+        &mut self,
+        _: &Variable,
+        text: &str,
+        core: &mut ShellCore,
+    ) -> Result<String, ExecError> {
         self.get_text(text, core)
     }
 
-    fn boxed_clone(&self) -> Box<dyn OptionalOperation> {Box::new(self.clone())}
+    fn boxed_clone(&self) -> Box<dyn OptionalOperation> {
+        Box::new(self.clone())
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -41,32 +50,30 @@ impl CaseConv {
         Ok("".to_string())
     }
 
-    fn get_match_length(&self, text: &str, pattern: &Vec<GlobElem>, ch: char) -> usize {
+    fn get_match_length(&self, text: &str, pattern: &[GlobElem], ch: char) -> usize {
         if pattern.is_empty() {
             return ch.len_utf8();
         }
-        glob::longest_match_length(&text.to_string(), &pattern)
+        glob::longest_match_length(text, pattern)
     }
 
     fn conv(&self, ch: char) -> String {
-        if 'a' <= ch && ch <= 'z' {
-            if self.replace_symbol.starts_with("^") 
-            || self.replace_symbol.starts_with("~") {
-                return ch.to_string().to_uppercase();
-            }
+        if ch.is_ascii_lowercase()
+            && (self.replace_symbol.starts_with("^") || self.replace_symbol.starts_with("~"))
+        {
+            return ch.to_string().to_uppercase();
         }
 
-        if 'A' <= ch && ch <= 'Z' {
-            if self.replace_symbol.starts_with(",") 
-            || self.replace_symbol.starts_with("~") {
-                return ch.to_string().to_lowercase();
-            }
+        if ch.is_ascii_uppercase()
+            && (self.replace_symbol.starts_with(",") || self.replace_symbol.starts_with("~"))
+        {
+            return ch.to_string().to_lowercase();
         }
 
         ch.to_string()
     }
 
-    pub fn get_text(&self, text: &String, core: &mut ShellCore) -> Result<String, ExecError> {
+    pub fn get_text(&self, text: &str, core: &mut ShellCore) -> Result<String, ExecError> {
         let tmp = self.to_string(&self.pattern, core)?;
         let extglob = core.shopts.query("extglob");
         let pattern = glob::parse(&tmp, extglob);
@@ -80,7 +87,7 @@ impl CaseConv {
                 start += ch.len_utf8();
                 continue;
             }
-    
+
             let len = self.get_match_length(&text[start..], &pattern, ch);
             if len == 0 {
                 ans += &ch.to_string();
@@ -91,7 +98,7 @@ impl CaseConv {
             let new_ch = self.conv(ch);
             ans += &new_ch;
             if self.replace_symbol.len() != 2 {
-                return Ok(ans + &text[start+len..]);
+                return Ok(ans + &text[start + len..]);
             }
 
             start += ch.len_utf8();
@@ -100,30 +107,28 @@ impl CaseConv {
     }
 
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Self>, ParseError> {
-        if ! feeder.starts_with("^") 
-        && ! feeder.starts_with(",") 
-        && ! feeder.starts_with("~") {
+        if !feeder.starts_with("^") && !feeder.starts_with(",") && !feeder.starts_with("~") {
             return Ok(None);
         }
 
         let mut ans = CaseConv::default();
 
-        if feeder.starts_with("^^") 
-        || feeder.starts_with(",,") 
-        || feeder.starts_with("~~") {
+        if feeder.starts_with("^^") || feeder.starts_with(",,") || feeder.starts_with("~~") {
             ans.replace_symbol = feeder.consume(2);
             ans.text += &ans.replace_symbol;
-        }else if feeder.starts_with("^") 
-        || feeder.starts_with(",") 
-        || feeder.starts_with("~") {
+        } else if feeder.starts_with("^") || feeder.starts_with(",") || feeder.starts_with("~") {
             ans.replace_symbol = feeder.consume(1);
             ans.text += &ans.replace_symbol;
         }
 
-        if let Some(w) = Word::parse(feeder, core, Some(WordMode::ParamOption(vec!["}".to_string()])))? {
+        if let Some(w) = Word::parse(
+            feeder,
+            core,
+            Some(WordMode::ParamOption(vec!["}".to_string()])),
+        )? {
             ans.text += &w.text.clone();
             ans.pattern = Some(w);
-        }else{
+        } else {
             ans.pattern = Some(Word::default());
         }
 

--- a/src/elements/subword/braced_param/optional_operation/remove.rs
+++ b/src/elements/subword/braced_param/optional_operation/remove.rs
@@ -1,38 +1,54 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{Feeder, ShellCore};
-use crate::elements::word::{Word, WordMode};
-use crate::utils::glob;
-use crate::error::parse::ParseError;
-use crate::error::exec::ExecError;
 use super::super::Variable;
 use super::OptionalOperation;
+use crate::elements::word::{Word, WordMode};
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::utils::glob;
+use crate::{Feeder, ShellCore};
 
 impl OptionalOperation for Remove {
-    fn get_text(&self) -> String {self.text.clone()}
-    fn exec(&mut self, _: &Variable, text: &String, core: &mut ShellCore) -> Result<String, ExecError> {
+    fn get_text(&self) -> String {
+        self.text.clone()
+    }
+    fn exec(
+        &mut self,
+        _: &Variable,
+        text: &str,
+        core: &mut ShellCore,
+    ) -> Result<String, ExecError> {
         self.set(text, core)
     }
 
-    fn boxed_clone(&self) -> Box<dyn OptionalOperation> {Box::new(self.clone())}
+    fn boxed_clone(&self) -> Box<dyn OptionalOperation> {
+        Box::new(self.clone())
+    }
 
-    fn set_array(&mut self, param: &Variable, array: &mut Vec<String>,
-                    text: &mut String, core: &mut ShellCore) -> Result<(), ExecError> {
+    fn set_array(
+        &mut self,
+        param: &Variable,
+        array: &mut Vec<String>,
+        text: &mut String,
+        core: &mut ShellCore,
+    ) -> Result<(), ExecError> {
         *array = match param.name.as_str() {
             "@" | "*" => core.db.get_position_params(),
             _ => core.db.get_vec(&param.name, true)?,
         };
 
-        for i in 0..array.len() {
-            array[i] = self.set(&array[i], core)?;
+        for item in array.iter_mut() {
+            *item = self.set(item, core)?;
         }
 
         *text = array.join(" ");
         Ok(())
     }
 
-    fn has_array_replace(&self) -> bool {true}
+    fn has_array_replace(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -43,12 +59,16 @@ pub struct Remove {
 }
 
 impl Remove {
-    pub fn set(&mut self, text: &String, core: &mut ShellCore) -> Result<String, ExecError> {
-        let mut text = text.clone();
-        let pattern = self.remove_pattern.as_mut().unwrap()
-                            .eval_for_case_word(core).ok_or(ExecError::Other("evaluation error".to_string()))?;
+    pub fn set(&mut self, text: &str, core: &mut ShellCore) -> Result<String, ExecError> {
+        let mut text = text.to_owned();
+        let pattern = self
+            .remove_pattern
+            .as_mut()
+            .unwrap()
+            .eval_for_case_word(core)
+            .ok_or(ExecError::Other("evaluation error".to_string()))?;
         let extglob = core.shopts.query("extglob");
-     
+
         if self.remove_symbol.starts_with("##") {
             let pat = glob::parse(&pattern, extglob);
             let len = glob::longest_match_length(&text, &pat);
@@ -57,31 +77,31 @@ impl Remove {
             let pat = glob::parse(&pattern, extglob);
             let len = glob::shortest_match_length(&text, &pat);
             text = text[len..].to_string();
-        }else if self.remove_symbol.starts_with("%") {
+        } else if self.remove_symbol.starts_with("%") {
             self.percent(&mut text, &pattern, extglob);
-        }else {
+        } else {
             return Err(ExecError::Other("unknown symbol".to_string()));
         }
 
         Ok(text)
     }
-    
-    pub fn percent(&self, text: &mut String, pattern: &String, extglob: bool) {
+
+    pub fn percent(&self, text: &mut String, pattern: &str, extglob: bool) {
         let mut length = text.len();
         let mut ans_length = length;
-     
+
         for ch in text.chars().rev() {
             length -= ch.len_utf8();
             let s = text[length..].to_string();
-     
-            if glob::parse_and_compare(&s, &pattern, extglob) {
+
+            if glob::parse_and_compare(&s, pattern, extglob) {
                 ans_length = length;
                 if self.remove_symbol == "%" {
                     break;
                 }
             }
         }
-     
+
         *text = text[0..ans_length].to_string();
     }
 
@@ -91,15 +111,20 @@ impl Remove {
             return Ok(None);
         }
 
-        let mut ans = Remove::default();
-
-        ans.remove_symbol = feeder.consume(len);
+        let mut ans = Remove {
+            remove_symbol: feeder.consume(len),
+            ..Default::default()
+        };
         ans.text += &ans.remove_symbol.clone();
 
-        if let Some(w) = Word::parse(feeder, core, Some(WordMode::ParamOption(vec!["}".to_string()])))? {
+        if let Some(w) = Word::parse(
+            feeder,
+            core,
+            Some(WordMode::ParamOption(vec!["}".to_string()])),
+        )? {
             ans.text += &w.text.clone();
             ans.remove_pattern = Some(w);
-        }else{
+        } else {
             ans.remove_pattern = Some(Word::default());
         }
         Ok(Some(ans))

--- a/src/elements/subword/braced_param/optional_operation/replace.rs
+++ b/src/elements/subword/braced_param/optional_operation/replace.rs
@@ -1,14 +1,14 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{Feeder, ShellCore};
-use crate::error::exec::ExecError;
+use super::super::optional_operation::OptionalOperation;
+use super::super::Variable;
 use crate::elements::word::{Word, WordMode};
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
 use crate::utils::glob;
 use crate::utils::glob::GlobElem;
-use crate::error::parse::ParseError;
-use super::super::Variable;
-use super::super::optional_operation::OptionalOperation;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone, Default)]
 pub struct Replace {
@@ -22,25 +22,39 @@ pub struct Replace {
 }
 
 impl OptionalOperation for Replace {
-    fn get_text(&self) -> String {self.text.clone()}
-    fn exec(&mut self, param: &Variable, text: &String, core: &mut ShellCore) -> Result<String, ExecError> {
+    fn get_text(&self) -> String {
+        self.text.clone()
+    }
+    fn exec(
+        &mut self,
+        param: &Variable,
+        text: &str,
+        core: &mut ShellCore,
+    ) -> Result<String, ExecError> {
         match core.db.has_value(&param.name) {
-            true  => self.get_text(text, core),
+            true => self.get_text(text, core),
             false => Ok("".to_string()),
         }
     }
 
-    fn boxed_clone(&self) -> Box<dyn OptionalOperation> {Box::new(self.clone())}
+    fn boxed_clone(&self) -> Box<dyn OptionalOperation> {
+        Box::new(self.clone())
+    }
 
-    fn set_array(&mut self, param: &Variable, array: &mut Vec<String>,
-                    text: &mut String, core: &mut ShellCore) -> Result<(), ExecError> {
+    fn set_array(
+        &mut self,
+        param: &Variable,
+        array: &mut Vec<String>,
+        text: &mut String,
+        core: &mut ShellCore,
+    ) -> Result<(), ExecError> {
         *array = match param.name.as_str() {
             "@" | "*" => core.db.get_position_params(),
             _ => core.db.get_vec(&param.name, true)?,
         };
 
-        for i in 0..array.len() {
-            array[i] = self.get_text(&array[i], core)?;
+        for item in array.iter_mut() {
+            *item = self.get_text(item, core)?;
         }
 
         let ifs = core.db.get_ifs_head();
@@ -49,7 +63,9 @@ impl OptionalOperation for Replace {
         Ok(())
     }
 
-    fn has_array_replace(&self) -> bool {true}
+    fn has_array_replace(&self) -> bool {
+        true
+    }
 }
 
 impl Replace {
@@ -67,28 +83,36 @@ impl Replace {
         Ok("".to_string())
     }
 
-    fn get_text_head(text: &String, pattern: &Vec<GlobElem>, string_to: &String) -> Result<String, ExecError> {
+    fn get_text_head(
+        text: &str,
+        pattern: &[GlobElem],
+        string_to: &str,
+    ) -> Result<String, ExecError> {
         let len = glob::longest_match_length(text, pattern);
-        if len == 0 && ! pattern.is_empty() {
-            return Ok(text.clone());
+        if len == 0 && !pattern.is_empty() {
+            return Ok(text.to_string());
         }
 
-        let ans = string_to.clone() + &text[len..];
+        let ans = string_to.to_string() + &text[len..];
         Ok(ans)
     }
 
-    fn get_text_tail(text: &String, pattern: &Vec<GlobElem>, string_to: &String) -> Result<String, ExecError> {
+    fn get_text_tail(
+        text: &str,
+        pattern: &[GlobElem],
+        string_to: &str,
+    ) -> Result<String, ExecError> {
         if pattern.is_empty() {
-            let ans = text.to_string() + &string_to;
+            let ans = text.to_string() + string_to;
             return Ok(ans);
         }
 
         let mut start = 0;
         for ch in text.chars() {
-            let len = glob::longest_match_length(&text[start..].to_string(), pattern);
+            let len = glob::longest_match_length(&text[start..], pattern);
 
             if len == text[start..].len() {
-                let ans = text[..start].to_string() + &string_to;
+                let ans = text[..start].to_string() + string_to;
                 return Ok(ans);
             }
 
@@ -98,7 +122,7 @@ impl Replace {
         Ok(text.to_string())
     }
 
-    pub fn get_text(&self, text: &String, core: &mut ShellCore) -> Result<String, ExecError> {
+    pub fn get_text(&self, text: &str, core: &mut ShellCore) -> Result<String, ExecError> {
         let extglob = core.shopts.query("extglob");
         let tmp = self.to_string(&self.replace_from, core)?;
         let pattern = glob::parse(&tmp, extglob);
@@ -106,7 +130,7 @@ impl Replace {
 
         if self.head_only_replace {
             return Self::get_text_head(text, &pattern, &string_to);
-        }else if self.tail_only_replace {
+        } else if self.tail_only_replace {
             return Self::get_text_tail(text, &pattern, &string_to);
         }
 
@@ -119,34 +143,34 @@ impl Replace {
                 start += ch.len_utf8();
                 continue;
             }
-    
-            let len = glob::longest_match_length(&text[start..].to_string(), &pattern);
+
+            let len = glob::longest_match_length(&text[start..], &pattern);
             if len != 0 && self.tail_only_replace {
                 if len == text[start..].len() {
-                    return Ok([&text[..start], &string_to[0..] ].concat());
-                }else{
+                    return Ok([&text[..start], &string_to[0..]].concat());
+                } else {
                     ans += &ch.to_string();
                     start += ch.len_utf8();
                     continue;
                 }
-            } else if len != 0 && ! self.all_replace {
-                return Ok([&text[..start], &string_to[0..], &text[start+len..] ].concat());
+            } else if len != 0 && !self.all_replace {
+                return Ok([&text[..start], &string_to[0..], &text[start + len..]].concat());
             }
-    
+
             if len != 0 {
-                skip = text[start..start+len].chars().count() - 1;
+                skip = text[start..start + len].chars().count() - 1;
                 ans += &string_to.clone();
-            }else{
+            } else {
                 ans += &ch.to_string();
             }
             start += ch.len_utf8();
         }
-    
+
         Ok(ans)
     }
 
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Self>, ParseError> {
-        if ! feeder.starts_with("/") {
+        if !feeder.starts_with("/") {
             return Ok(None);
         }
 
@@ -156,31 +180,42 @@ impl Replace {
         if feeder.starts_with("/") {
             ans.text += &feeder.consume(1);
             ans.all_replace = true;
-        }else if feeder.starts_with("#") {
+        } else if feeder.starts_with("#") {
             ans.text += &feeder.consume(1);
             ans.head_only_replace = true;
-        }else if feeder.starts_with("%") {
+        } else if feeder.starts_with("%") {
             ans.text += &feeder.consume(1);
             ans.tail_only_replace = true;
         }
 
-        if let Some(w) = Word::parse(feeder, core, Some(WordMode::ParamOption(vec!["}".to_string(), "/".to_string()])))? {
+        if let Some(w) = Word::parse(
+            feeder,
+            core,
+            Some(WordMode::ParamOption(vec![
+                "}".to_string(),
+                "/".to_string(),
+            ])),
+        )? {
             ans.text += &w.text.clone();
             ans.replace_from = Some(w);
-        }else{
+        } else {
             ans.replace_from = Some(Word::default());
         }
 
-        if ! feeder.starts_with("/") {
+        if !feeder.starts_with("/") {
             return Ok(Some(ans));
         }
         ans.text += &feeder.consume(1);
         ans.has_replace_to = true;
 
-        if let Some(w) = Word::parse(feeder, core, Some(WordMode::ParamOption(vec!["}".to_string()])))? {
+        if let Some(w) = Word::parse(
+            feeder,
+            core,
+            Some(WordMode::ParamOption(vec!["}".to_string()])),
+        )? {
             ans.text += &w.text.clone();
             ans.replace_to = Some(w);
-        }else{
+        } else {
             ans.replace_to = Some(Word::default());
         }
 

--- a/src/elements/subword/braced_param/optional_operation/substr.rs
+++ b/src/elements/subword/braced_param/optional_operation/substr.rs
@@ -1,12 +1,12 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{Feeder, ShellCore};
-use crate::error::arith::ArithError;
-use crate::error::exec::ExecError;
-use crate::elements::expr::arithmetic::ArithmeticExpr;
 use super::super::Variable;
 use super::OptionalOperation;
+use crate::elements::expr::arithmetic::ArithmeticExpr;
+use crate::error::arith::ArithError;
+use crate::error::exec::ExecError;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone, Default)]
 pub struct Substr {
@@ -16,32 +16,52 @@ pub struct Substr {
 }
 
 impl OptionalOperation for Substr {
-    fn get_text(&self) -> String {self.text.clone()}
-    fn exec(&mut self, _: &Variable, text: &String, core: &mut ShellCore) -> Result<String, ExecError> {
+    fn get_text(&self) -> String {
+        self.text.clone()
+    }
+    fn exec(
+        &mut self,
+        _: &Variable,
+        text: &str,
+        core: &mut ShellCore,
+    ) -> Result<String, ExecError> {
         self.get(text, core)
     }
 
-    fn boxed_clone(&self) -> Box<dyn OptionalOperation> {Box::new(self.clone())}
-    fn has_array_replace(&self) -> bool {true}
+    fn boxed_clone(&self) -> Box<dyn OptionalOperation> {
+        Box::new(self.clone())
+    }
+    fn has_array_replace(&self) -> bool {
+        true
+    }
 
-    fn set_array(&mut self, param: &Variable, array: &mut Vec<String>,
-                    text: &mut String, core: &mut ShellCore) -> Result<(), ExecError> {
+    fn set_array(
+        &mut self,
+        param: &Variable,
+        array: &mut Vec<String>,
+        text: &mut String,
+        core: &mut ShellCore,
+    ) -> Result<(), ExecError> {
         match param.name.as_str() {
             "@" | "*" => self.set_partial_position_params(array, text, core),
-            _   => self.set_partial_array(&param.name, array, text, core),
+            _ => self.set_partial_array(&param.name, array, text, core),
         }
     }
 }
 
 impl Substr {
-    fn set_partial_position_params(&mut self, array: &mut Vec<String>,
-                    text: &mut String, core: &mut ShellCore) -> Result<(), ExecError> {
+    fn set_partial_position_params(
+        &mut self,
+        array: &mut Vec<String>,
+        text: &mut String,
+        core: &mut ShellCore,
+    ) -> Result<(), ExecError> {
         let offset = self.offset.as_mut().unwrap();
-    
-        if offset.text == "" {
+
+        if offset.text.is_empty() {
             return Err(ExecError::BadSubstitution(String::new()));
         }
-    
+
         *array = core.db.get_vec("@", false)?;
         let mut n = offset.eval_as_int(core)?;
         let len = array.len();
@@ -55,45 +75,48 @@ impl Substr {
             }
         }
 
-
         let mut start = std::cmp::max(0, n) as usize;
-        start = std::cmp::min(start, array.len()) as usize;
+        start = std::cmp::min(start, array.len());
         *array = array.split_off(start);
-    
+
         if self.length.is_none() {
             *text = array.join(" ");
             return Ok(());
         }
 
-    
         let mut length = match self.length.clone() {
             None => return Err(ExecError::BadSubstitution("".to_string())),
             Some(ofs) => ofs,
         };
-    
-        if length.text == "" {
+
+        if length.text.is_empty() {
             return Err(ExecError::BadSubstitution("".to_string()));
         }
-    
+
         let n = length.eval_as_int(core)?;
         if n < 0 {
             return Err(ExecError::SubstringMinus(n));
         }
         let len = std::cmp::min(n as usize, array.len());
         let _ = array.split_off(len);
-    
+
         *text = array.join(" ");
         Ok(())
     }
 
-    fn set_partial_array(&mut self, name: &str, array: &mut Vec<String>,
-                    text: &mut String, core: &mut ShellCore) -> Result<(), ExecError> {
+    fn set_partial_array(
+        &mut self,
+        name: &str,
+        array: &mut Vec<String>,
+        text: &mut String,
+        core: &mut ShellCore,
+    ) -> Result<(), ExecError> {
         let offset = self.offset.as_mut().unwrap();
-    
-        if offset.text == "" {
+
+        if offset.text.is_empty() {
             return Err(ExecError::BadSubstitution(String::new()));
         }
-    
+
         let mut n = offset.eval_as_int(core)?;
         let len = core.db.index_based_len(name);
         if n < 0 {
@@ -113,36 +136,35 @@ impl Substr {
             *text = array.join(" ");
             return Ok(());
         }
-    
+
         let mut length = match self.length.clone() {
             None => return Err(ExecError::BadSubstitution("".to_string())),
             Some(ofs) => ofs,
         };
-    
-        if length.text == "" {
+
+        if length.text.is_empty() {
             return Err(ExecError::BadSubstitution("".to_string()));
         }
-    
+
         let n = length.eval_as_int(core)?;
         if n < 0 {
             return Err(ExecError::SubstringMinus(n));
         }
         let len = std::cmp::min(n as usize, array.len());
         let _ = array.split_off(len);
-    
+
         *text = array.join(" ");
         Ok(())
     }
 
-    pub fn get(&mut self, text: &String, core: &mut ShellCore) -> Result<String, ExecError> {
+    pub fn get(&mut self, text: &str, core: &mut ShellCore) -> Result<String, ExecError> {
         let offset = self.offset.as_mut().unwrap();
-    
-        if offset.text == "" {
+
+        if offset.text.is_empty() {
             let err = ArithError::OperandExpected("".to_string());
             return Err(ExecError::ArithError("".to_string(), err));
         }
-    
-        let mut ans;
+
         let mut n = offset.eval_as_int(core)?;
         let len = text.chars().count();
 
@@ -153,26 +175,32 @@ impl Substr {
             }
         }
 
-        ans = text.chars().enumerate()
+        let mut ans: String = text
+            .chars()
+            .enumerate()
             .filter(|(i, _)| (*i as i128) >= n)
-            .map(|(_, c)| c).collect();
-    
+            .map(|(_, c)| c)
+            .collect();
+
         if self.length.is_some() {
             ans = self.length(&ans, core)?;
         }
-    
+
         Ok(ans)
     }
-    
-    fn length(&mut self, text: &String, core: &mut ShellCore) -> Result<String, ExecError> {
+
+    fn length(&mut self, text: &str, core: &mut ShellCore) -> Result<String, ExecError> {
         let n = self.length.as_mut().unwrap().eval_as_int(core)?;
-        Ok(text.chars().enumerate()
+        Ok(text
+            .chars()
+            .enumerate()
             .filter(|(i, _)| (*i as i128) < n)
-            .map(|(_, c)| c).collect())
+            .map(|(_, c)| c)
+            .collect())
     }
 
     fn eat_length(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) {
-        if ! feeder.starts_with(":") {
+        if !feeder.starts_with(":") {
             return;
         }
         ans.text += &feeder.consume(1);
@@ -180,13 +208,13 @@ impl Substr {
             Ok(Some(a)) => {
                 ans.text += &a.text.clone();
                 Some(a)
-            },
+            }
             _ => None,
         };
     }
 
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Option<Self> {
-        if ! feeder.starts_with(":") {
+        if !feeder.starts_with(":") {
             return None;
         }
         let mut ans = Self::default();
@@ -197,7 +225,7 @@ impl Substr {
                 ans.text += &a.text.clone();
                 Self::eat_length(feeder, &mut ans, core);
                 Some(a)
-            },
+            }
             _ => None,
         };
 

--- a/src/elements/subword/braced_param/parse.rs
+++ b/src/elements/subword/braced_param/parse.rs
@@ -1,17 +1,21 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
+use super::optional_operation;
+use super::{BracedParam, Variable};
 use crate::elements::substitution::subscript::Subscript;
 use crate::error::parse::ParseError;
-use super::{BracedParam, Variable};
-use super::optional_operation;
+use crate::{Feeder, ShellCore};
 
 impl BracedParam {
-    fn eat_subscript(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> Result<bool, ParseError> {
+    fn eat_subscript(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<bool, ParseError> {
         if let Some(s) = Subscript::parse(feeder, core)? {
             ans.text += &s.text;
-            if s.text.contains('@') && ! ans.num {
+            if s.text.contains('@') && !ans.num {
                 ans.treat_as_array = true;
             }
             ans.param.index = Some(s);
@@ -38,7 +42,7 @@ impl BracedParam {
         if len != 0 {
             ans.param = Variable::default();
             ans.param.name = feeder.consume(len);
-            ans.treat_as_array = ans.param.name == "@" && ! ans.num;
+            ans.treat_as_array = ans.param.name == "@" && !ans.num;
             ans.text += &ans.param.name;
             return true;
         }
@@ -46,17 +50,21 @@ impl BracedParam {
         feeder.starts_with("}")
     }
 
-    fn eat_unknown(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> Result<(), ParseError> {
-        if feeder.len() == 0 {
+    fn eat_unknown(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<(), ParseError> {
+        if feeder.is_empty() {
             feeder.feed_additional_line(core)?;
         }
 
         let unknown = match feeder.starts_with("\\}") {
-            true  => feeder.consume(2),
+            true => feeder.consume(2),
             false => {
                 let len = feeder.scanner_char(); //feeder.nth(0).unwrap().len_utf8();
                 feeder.consume(len)
-            },
+            }
         };
 
         ans.unknown += &unknown.clone();
@@ -65,16 +73,16 @@ impl BracedParam {
     }
 
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Self>, ParseError> {
-        if ! feeder.starts_with("${") {
+        if !feeder.starts_with("${") {
             return Ok(None);
         }
         let mut ans = Self::default();
         ans.text += &feeder.consume(2);
 
-        if feeder.starts_with("#") && ! feeder.starts_with("#}") {
+        if feeder.starts_with("#") && !feeder.starts_with("#}") {
             ans.num = true;
             ans.text += &feeder.consume(1);
-        }else if feeder.starts_with("!") {
+        } else if feeder.starts_with("!") {
             ans.indirect = true;
             ans.text += &feeder.consume(1);
         }
@@ -87,7 +95,7 @@ impl BracedParam {
                 ans.optional_operation = Some(op);
             }
         }
-        while ! feeder.starts_with("}") {
+        while !feeder.starts_with("}") {
             Self::eat_unknown(feeder, &mut ans, core)?;
         }
 

--- a/src/elements/subword/command_sub.rs
+++ b/src/elements/subword/command_sub.rs
@@ -1,19 +1,19 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{proc_ctrl, ShellCore, Feeder};
-use crate::elements::Pipe;
-use crate::elements::command::Command;
 use crate::elements::command::paren::ParenCommand;
+use crate::elements::command::Command;
 use crate::elements::subword::Subword;
-use crate::error::parse::ParseError;
+use crate::elements::Pipe;
 use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{proc_ctrl, Feeder, ShellCore};
 use nix::unistd;
-use std::{thread, time};
 use std::fs::File;
-use std::io::{BufReader, BufRead, Error};
+use std::io::{BufRead, BufReader, Error};
 use std::os::fd::{FromRawFd, RawFd};
 use std::sync::atomic::Ordering::Relaxed;
+use std::{thread, time};
 
 #[derive(Debug, Clone, Default)]
 pub struct CommandSubstitution {
@@ -22,8 +22,12 @@ pub struct CommandSubstitution {
 }
 
 impl Subword for CommandSubstitution {
-    fn get_text(&self) -> &str {&self.text.as_ref()}
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
 
     fn substitute(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
         let mut pipe = Pipe::new("|".to_string());
@@ -48,11 +52,12 @@ impl CommandSubstitution {
     }
 
     fn interrupted(&mut self, count: usize, core: &mut ShellCore) -> Result<(), ExecError> {
-        if count%100 == 99 { //To receive Ctrl+C
+        if count % 100 == 99 {
+            //To receive Ctrl+C
             thread::sleep(time::Duration::from_millis(1));
         }
         match core.sigint.load(Relaxed) {
-            true  => Err(ExecError::Interrupted),
+            true => Err(ExecError::Interrupted),
             false => Ok(()),
         }
     }
@@ -63,7 +68,7 @@ impl CommandSubstitution {
         self.text.clear();
         for (i, line) in reader.lines().enumerate() {
             self.interrupted(i, core)?;
-            if ! self.set_line(line) {
+            if !self.set_line(line) {
                 break;
             }
         }
@@ -72,16 +77,20 @@ impl CommandSubstitution {
         Ok(())
     }
 
-    pub fn parse_old_style(feeder: &mut Feeder, core: &mut ShellCore)
-    -> Result<Option<Self>, ParseError> {
-        if ! feeder.starts_with("`") {
+    pub fn parse_old_style(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+    ) -> Result<Option<Self>, ParseError> {
+        if !feeder.starts_with("`") {
             return Ok(None);
         }
 
-        let mut ans = Self::default();
-        ans.text = feeder.consume(1);
+        let mut ans = Self {
+            text: feeder.consume(1),
+            ..Default::default()
+        };
         let mut esc = false;
-        while esc || ! feeder.starts_with("`") {
+        while esc || !feeder.starts_with("`") {
             if feeder.is_empty() {
                 feeder.feed_additional_line(core)?;
                 continue;
@@ -96,7 +105,7 @@ impl CommandSubstitution {
 
             ans.text += &c;
 
-            if ! esc && c == "\\" {
+            if !esc && c == "\\" {
                 esc = true;
                 continue;
             }
@@ -124,18 +133,20 @@ impl CommandSubstitution {
         if let Some(ans) = Self::parse_old_style(feeder, core)? {
             return Ok(Some(ans));
         }
-        
-        if ! feeder.starts_with("$(") {
+
+        if !feeder.starts_with("$(") {
             return Ok(None);
         }
-        let mut ans = Self::default();
-        ans.text = feeder.consume(1);
+        let mut ans = Self {
+            text: feeder.consume(1),
+            ..Default::default()
+        };
 
         if let Some(pc) = ParenCommand::parse(feeder, core, true)? {
             ans.text += &pc.get_text();
             ans.command = pc;
             Ok(Some(ans))
-        }else{
+        } else {
             Ok(None)
         }
     }

--- a/src/elements/subword/double_quoted.rs
+++ b/src/elements/subword/double_quoted.rs
@@ -1,12 +1,12 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
-use crate::error::parse::ParseError;
-use crate::error::exec::ExecError;
-use crate::elements::word::{Word, WordMode, substitution};
-use crate::elements::subword::{Arithmetic, CommandSubstitution};
 use super::{BracedParam, EscapedChar, Parameter, Subword, VarName};
+use crate::elements::subword::{Arithmetic, CommandSubstitution};
+use crate::elements::word::{substitution, Word, WordMode};
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone, Default)]
 pub struct DoubleQuoted {
@@ -16,14 +16,18 @@ pub struct DoubleQuoted {
 }
 
 impl Subword for DoubleQuoted {
-    fn get_text(&self) -> &str {&self.text.as_ref()}
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
 
     fn substitute(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
         self.connect_array(core)?;
 
         let mut word = match self.subwords.iter().any(|sw| sw.is_array()) {
-            true  => Word::from(self.replace_array(core)?),
+            true => Word::from(self.replace_array(core)?),
             false => Word::from(self.subwords.clone()),
         };
 
@@ -41,14 +45,15 @@ impl Subword for DoubleQuoted {
     }
 
     fn make_glob_string(&mut self) -> String {
-        return self.text.replace("\\", "\\\\")
-                        .replace("*", "\\*")
-                        .replace("?", "\\?")
-                        .replace("[", "\\[")
-                        .replace("]", "\\]")
-                        .replace("@", "\\@")
-                        .replace("+", "\\+")
-                        .replace("!", "\\!")
+        self.text
+            .replace("\\", "\\\\")
+            .replace("*", "\\*")
+            .replace("?", "\\?")
+            .replace("[", "\\[")
+            .replace("]", "\\]")
+            .replace("@", "\\@")
+            .replace("+", "\\+")
+            .replace("!", "\\!")
     }
 
     fn make_unquoted_string(&mut self) -> Option<String> {
@@ -71,7 +76,7 @@ impl Subword for DoubleQuoted {
         Some(text)
     }
 
-    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)>{
+    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)> {
         let mut ans = vec![];
         let mut last = 0;
         let mut tmp = Self::default();
@@ -100,7 +105,7 @@ impl DoubleQuoted {
         let mut ans = vec![];
 
         for sw in &mut self.subwords {
-            if ! sw.is_array() {
+            if !sw.is_array() {
                 ans.push(sw.boxed_clone());
                 continue;
             }
@@ -110,7 +115,7 @@ impl DoubleQuoted {
                 _ => {
                     sw.substitute(core)?;
                     sw.get_elem()
-                },
+                }
             };
 
             for text in array {
@@ -124,16 +129,28 @@ impl DoubleQuoted {
         Ok(ans)
     }
 
-    fn eat_element(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> Result<bool, ParseError> {
-        let sw: Box<dyn Subword> 
-            = if let Some(a) = BracedParam::parse(feeder, core)? {Box::new(a)}
-            else if let Some(a) = Arithmetic::parse(feeder, core)? {Box::new(a)}
-            else if let Some(a) = CommandSubstitution::parse(feeder, core)? {Box::new(a)}
-            //else if let Some(a) = CommandSubstitutionOld::parse(feeder, core)? {Box::new(a)}
-            else if let Some(a) = Parameter::parse(feeder, core) {Box::new(a)}
-            else if let Some(a) = Self::parse_escaped_char(feeder) { Box::new(a) }
-            else if let Some(a) = Self::parse_name(feeder, core) { Box::new(a) }
-            else { return Ok(false) ; };
+    fn eat_element(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<bool, ParseError> {
+        let sw: Box<dyn Subword> = if let Some(a) = BracedParam::parse(feeder, core)? {
+            Box::new(a)
+        } else if let Some(a) = Arithmetic::parse(feeder, core)? {
+            Box::new(a)
+        } else if let Some(a) = CommandSubstitution::parse(feeder, core)? {
+            Box::new(a)
+        }
+        //else if let Some(a) = CommandSubstitutionOld::parse(feeder, core)? {Box::new(a)}
+        else if let Some(a) = Parameter::parse(feeder, core) {
+            Box::new(a)
+        } else if let Some(a) = Self::parse_escaped_char(feeder) {
+            Box::new(a)
+        } else if let Some(a) = Self::parse_name(feeder, core) {
+            Box::new(a)
+        } else {
+            return Ok(false);
+        };
 
         ans.text += sw.get_text();
         ans.subwords.push(sw);
@@ -141,9 +158,14 @@ impl DoubleQuoted {
     }
 
     fn parse_escaped_char(feeder: &mut Feeder) -> Option<EscapedChar> {
-        if feeder.starts_with("\\$") || feeder.starts_with("\\\\") 
-        || feeder.starts_with("\\\"") || feeder.starts_with("\\`") {
-            return Some(EscapedChar{ text: feeder.consume(2) });
+        if feeder.starts_with("\\$")
+            || feeder.starts_with("\\\\")
+            || feeder.starts_with("\\\"")
+            || feeder.starts_with("\\`")
+        {
+            return Some(EscapedChar {
+                text: feeder.consume(2),
+            });
         }
         None
     }
@@ -151,12 +173,17 @@ impl DoubleQuoted {
     fn parse_name(feeder: &mut Feeder, core: &mut ShellCore) -> Option<VarName> {
         match feeder.scanner_name(core) {
             0 => None,
-            n => Some(VarName{ text: feeder.consume(n) }),
+            n => Some(VarName {
+                text: feeder.consume(n),
+            }),
         }
     }
 
-    fn eat_char(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore)
-    -> Result<bool, ParseError> {
+    fn eat_char(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<bool, ParseError> {
         let len = feeder.scanner_char();
         if len == 0 {
             feeder.feed_additional_line(core)?;
@@ -166,15 +193,18 @@ impl DoubleQuoted {
         let ch = feeder.consume(len);
         ans.text += &ch.clone();
         if ch != "\"" {
-            ans.subwords.push( From::from(&ch) );
+            ans.subwords.push(From::from(&ch));
             return Ok(true);
         }
         Ok(false)
     }
 
-    pub fn parse(feeder: &mut Feeder, core: &mut ShellCore,
-                 mode: &Option<WordMode>) -> Result<Option<Self>, ParseError> {
-        if ! feeder.starts_with("\"") && ! feeder.starts_with("$\"")  {
+    pub fn parse(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+        mode: &Option<WordMode>,
+    ) -> Result<Option<Self>, ParseError> {
+        if !feeder.starts_with("\"") && !feeder.starts_with("$\"") {
             return Ok(None);
         }
         if let Some(WordMode::Heredoc) = mode {
@@ -184,12 +214,13 @@ impl DoubleQuoted {
         let mut ans = Self::default();
         feeder.nest.push(("\"".to_string(), vec!["\"".to_string()]));
 
-        let len = if feeder.starts_with("\""){1}else{2};
+        let len = if feeder.starts_with("\"") { 1 } else { 2 };
 
         ans.text = feeder.consume(len);
 
-        while Self::eat_element(feeder, &mut ans, core)?
-           || Self::eat_char(feeder, &mut ans, core)? {}
+        while Self::eat_element(feeder, &mut ans, core)? || Self::eat_char(feeder, &mut ans, core)?
+        {
+        }
 
         feeder.nest.pop();
         Ok(Some(ans))

--- a/src/elements/subword/escaped_char.rs
+++ b/src/elements/subword/escaped_char.rs
@@ -1,9 +1,9 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
-use crate::utils::exit;
 use crate::elements::subword::Subword;
+use crate::utils::exit;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone)]
 pub struct EscapedChar {
@@ -11,8 +11,12 @@ pub struct EscapedChar {
 }
 
 impl Subword for EscapedChar {
-    fn get_text(&self) -> &str {&self.text.as_ref()}
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
 
     fn make_unquoted_string(&mut self) -> Option<String> {
         match self.text.len() {
@@ -24,21 +28,25 @@ impl Subword for EscapedChar {
 
     fn make_glob_string(&mut self) -> String {
         if let Some(c) = self.text.chars().nth(1) {
-            if ! "*?[]^!\\".contains(c) {
+            if !"*?[]^!\\".contains(c) {
                 return c.to_string();
             }
         }
         self.text.clone()
     }
 
-    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)>{ vec![] }
+    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)> {
+        vec![]
+    }
 }
 
 impl EscapedChar {
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Option<Self> {
         match feeder.scanner_escaped_char(core) {
             0 => None,
-            n => Some(EscapedChar{ text: feeder.consume(n) }),
+            n => Some(EscapedChar {
+                text: feeder.consume(n),
+            }),
         }
     }
 }

--- a/src/elements/subword/ext_glob.rs
+++ b/src/elements/subword/ext_glob.rs
@@ -1,11 +1,11 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
+use super::{BracedParam, EscapedChar, Parameter, Subword, VarName};
+use crate::elements::subword::CommandSubstitution;
 use crate::error::parse::ParseError;
 use crate::utils::exit;
-use crate::elements::subword::CommandSubstitution;
-use super::{BracedParam, EscapedChar, Parameter, Subword, VarName};
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone)]
 pub struct ExtGlob {
@@ -14,11 +14,21 @@ pub struct ExtGlob {
 }
 
 impl Subword for ExtGlob {
-    fn get_text(&self) -> &str {&self.text.as_ref()}
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
-    fn get_child_subwords(&self) -> Vec<Box<dyn Subword>> { self.subwords.clone() }
-    fn is_extglob(&self) -> bool {true}
-    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)>{ vec![] }
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
+    fn get_child_subwords(&self) -> Vec<Box<dyn Subword>> {
+        self.subwords.clone()
+    }
+    fn is_extglob(&self) -> bool {
+        true
+    }
+    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)> {
+        vec![]
+    }
 }
 
 impl ExtGlob {
@@ -36,33 +46,44 @@ impl ExtGlob {
 
         let txt = feeder.consume(len);
         ans.text += &txt;
-        ans.subwords.push( From::from(&txt) );
+        ans.subwords.push(From::from(&txt));
         true
     }
 
-    fn eat_braced_param(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> Result<bool, ParseError> {
+    fn eat_braced_param(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<bool, ParseError> {
         if let Some(a) = BracedParam::parse(feeder, core)? {
             ans.text += a.get_text();
             ans.subwords.push(Box::new(a));
             Ok(true)
-        }else{
+        } else {
             Ok(false)
         }
     }
 
-    fn eat_command_substitution(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore)
-        -> Result<bool, ParseError> {
+    fn eat_command_substitution(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<bool, ParseError> {
         if let Some(a) = CommandSubstitution::parse(feeder, core)? {
             ans.text += a.get_text();
             ans.subwords.push(Box::new(a));
             Ok(true)
-        }else{
+        } else {
             Ok(false)
         }
     }
 
-    fn eat_special_or_positional_param(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> bool {
-        if let Some(a) = Parameter::parse(feeder, core){
+    fn eat_special_or_positional_param(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> bool {
+        if let Some(a) = Parameter::parse(feeder, core) {
             ans.text += a.get_text();
             ans.subwords.push(Box::new(a));
             return true;
@@ -71,19 +92,23 @@ impl ExtGlob {
         false
     }
 
-    fn eat_extglob(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> Result<bool, ParseError> {
+    fn eat_extglob(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<bool, ParseError> {
         if let Some(a) = Self::parse(feeder, core)? {
             ans.text += a.get_text();
             ans.subwords.push(Box::new(a));
             Ok(true)
-        }else{
+        } else {
             Ok(false)
         }
     }
 
     fn eat_doller(feeder: &mut Feeder, ans: &mut Self) -> bool {
         match feeder.starts_with("$") {
-            true  => Self::set_simple_subword(feeder, ans, 1),
+            true => Self::set_simple_subword(feeder, ans, 1),
             false => false,
         }
     }
@@ -97,7 +122,7 @@ impl ExtGlob {
         if feeder.starts_with("\\$") || feeder.starts_with("\\\\") {
             let txt = feeder.consume(2);
             ans.text += &txt;
-            ans.subwords.push(Box::new(EscapedChar{ text: txt }));
+            ans.subwords.push(Box::new(EscapedChar { text: txt }));
             return true;
         }
         let len = feeder.scanner_escaped_char(core);
@@ -112,7 +137,7 @@ impl ExtGlob {
 
         let txt = feeder.consume(len);
         ans.text += &txt;
-        ans.subwords.push(Box::new( VarName{ text: txt}));
+        ans.subwords.push(Box::new(VarName { text: txt }));
         true
     }
 
@@ -122,36 +147,36 @@ impl ExtGlob {
     }
 
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Self>, ParseError> {
-        if ! core.shopts.query("extglob") 
-        || feeder.scanner_extglob_head() == 0 {
+        if !core.shopts.query("extglob") || feeder.scanner_extglob_head() == 0 {
             return Ok(None);
         }
 
         let mut ans = Self::new();
         ans.text = feeder.consume(2);
-        ans.subwords.push( From::from(&ans.text) );
+        ans.subwords.push(From::from(&ans.text));
 
         loop {
             while Self::eat_braced_param(feeder, &mut ans, core)?
-               || Self::eat_command_substitution(feeder, &mut ans, core)?
-               || Self::eat_extglob(feeder, &mut ans, core)?
-               || Self::eat_special_or_positional_param(feeder, &mut ans, core)
-               || Self::eat_doller(feeder, &mut ans)
-               || Self::eat_escaped_char(feeder, &mut ans, core)
-               || Self::eat_name(feeder, &mut ans, core)
-               || Self::eat_symbol(feeder, &mut ans)
-               || Self::eat_other(feeder, &mut ans, core) {}
+                || Self::eat_command_substitution(feeder, &mut ans, core)?
+                || Self::eat_extglob(feeder, &mut ans, core)?
+                || Self::eat_special_or_positional_param(feeder, &mut ans, core)
+                || Self::eat_doller(feeder, &mut ans)
+                || Self::eat_escaped_char(feeder, &mut ans, core)
+                || Self::eat_name(feeder, &mut ans, core)
+                || Self::eat_symbol(feeder, &mut ans)
+                || Self::eat_other(feeder, &mut ans, core)
+            {}
 
             if feeder.starts_with(")") {
                 ans.text += &feeder.consume(1);
-                ans.subwords.push( From::from(")") );
+                ans.subwords.push(From::from(")"));
                 return Ok(Some(ans));
-            }else if feeder.starts_with("|") {
+            } else if feeder.starts_with("|") {
                 ans.text += &feeder.consume(1);
-                ans.subwords.push( From::from("|") );
-            }else if feeder.len() > 0 {
+                ans.subwords.push(From::from("|"));
+            } else if !feeder.is_empty() {
                 exit::internal("unknown chars in double quoted word");
-            }else if ! feeder.feed_additional_line(core).is_ok() {
+            } else if feeder.feed_additional_line(core).is_err() {
                 return Ok(None);
             }
         }

--- a/src/elements/subword/file_input.rs
+++ b/src/elements/subword/file_input.rs
@@ -1,12 +1,12 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
 use crate::elements::command;
 use crate::elements::io::redirect::Redirect;
 use crate::elements::subword::Subword;
-use crate::error::parse::ParseError;
 use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
@@ -17,13 +17,19 @@ pub struct FileInput {
 }
 
 impl Subword for FileInput {
-    fn get_text(&self) -> &str {&self.text.as_ref()}
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
 
     fn substitute(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
         let args = self.redirect.right.eval(core)?;
         if args.len() != 1 {
-            return Err(ExecError::AmbiguousRedirect(self.redirect.right.text.clone()));
+            return Err(ExecError::AmbiguousRedirect(
+                self.redirect.right.text.clone(),
+            ));
         }
 
         let file = match File::open(&args[0]) {
@@ -37,7 +43,7 @@ impl Subword for FileInput {
                 Ok(ln) => {
                     self.text += &ln;
                     self.text += " ";
-                },
+                }
                 Err(e) => return Err(ExecError::Other(e.to_string())),
             }
         }
@@ -49,13 +55,14 @@ impl Subword for FileInput {
 
 impl FileInput {
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Result<Option<Self>, ParseError> {
-        if ! feeder.starts_with("$(") {
+        if !feeder.starts_with("$(") {
             return Ok(None);
         }
         feeder.set_backup();
-        let mut ans = Self::default();
-
-        ans.text = feeder.consume(2);
+        let mut ans = Self {
+            text: feeder.consume(2),
+            ..Default::default()
+        };
 
         if let Err(e) = command::eat_blank_lines(feeder, core, &mut ans.text) {
             feeder.rewind();
@@ -68,8 +75,7 @@ impl FileInput {
             return Err(e);
         }
 
-        if redirects.len() != 1 
-        || redirects[0].symbol != "<" {
+        if redirects.len() != 1 || redirects[0].symbol != "<" {
             feeder.rewind();
             return Ok(None);
         }
@@ -81,7 +87,7 @@ impl FileInput {
 
         ans.redirect = redirects.pop().unwrap();
 
-        if ! feeder.starts_with(")") {
+        if !feeder.starts_with(")") {
             feeder.rewind();
             return Ok(None);
         }

--- a/src/elements/subword/filler.rs
+++ b/src/elements/subword/filler.rs
@@ -10,7 +10,13 @@ pub struct FillerSubword {
 }
 
 impl Subword for FillerSubword {
-    fn get_text(&self) -> &str {&self.text.as_ref()}
-    fn set_text(&mut self, text: &str) { self.text = text.to_string(); }
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn set_text(&mut self, text: &str) {
+        self.text = text.to_string();
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
 }

--- a/src/elements/subword/parameter.rs
+++ b/src/elements/subword/parameter.rs
@@ -1,10 +1,10 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
-use crate::utils::splitter;
-use crate::error::exec::ExecError;
 use super::Subword;
+use crate::error::exec::ExecError;
+use crate::utils::splitter;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone, Default)]
 pub struct Parameter {
@@ -13,11 +13,15 @@ pub struct Parameter {
 }
 
 impl Subword for Parameter {
-    fn get_text(&self) -> &str {&self.text.as_ref()}
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
 
     fn substitute(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
-        if ! self.text.starts_with("$") {
+        if !self.text.starts_with("$") {
             return Ok(());
         }
 
@@ -29,21 +33,25 @@ impl Subword for Parameter {
         Ok(())
     }
 
-    fn is_array(&self) -> bool {self.text == "$@"}
+    fn is_array(&self) -> bool {
+        self.text == "$@"
+    }
 
-    fn split(&self, ifs: &str, prev_char: Option<char>) -> Vec<(Box<dyn Subword>, bool)>{ 
-        if self.text == "" {
+    fn split(&self, ifs: &str, prev_char: Option<char>) -> Vec<(Box<dyn Subword>, bool)> {
+        if self.text.is_empty() {
             return vec![];
         }
 
         if ifs.starts_with(" ") || self.array.is_none() {
-            return splitter::split(&self.get_text(), ifs, prev_char).iter()
-                .map(|s| ( From::from(&s.0), s.1)).collect();
+            return splitter::split(self.get_text(), ifs, prev_char)
+                .iter()
+                .map(|s| (From::from(&s.0), s.1))
+                .collect();
         }
 
         let mut ans = vec![];
         for p in self.array.clone().unwrap() {
-            ans.push( (From::from(&p), true) );
+            ans.push((From::from(&p), true));
         }
         ans
     }
@@ -54,10 +62,12 @@ impl Parameter {
         match feeder.scanner_dollar_special_and_positional_param(core) {
             0 => None,
             n => {
-                let mut ans = Self::default();
-                ans.text = feeder.consume(n);
+                let ans = Self {
+                    text: feeder.consume(n),
+                    ..Default::default()
+                };
                 Some(ans)
-            },
+            }
         }
     }
 }

--- a/src/elements/subword/paren.rs
+++ b/src/elements/subword/paren.rs
@@ -1,12 +1,12 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
-use crate::error::parse::ParseError;
-use crate::error::exec::ExecError;
-use crate::elements::word::{Word, WordMode};
-use crate::elements::subword::{Arithmetic, CommandSubstitution, DoubleQuoted};
 use super::{BracedParam, EscapedChar, Parameter, Subword, VarName};
+use crate::elements::subword::{Arithmetic, CommandSubstitution, DoubleQuoted};
+use crate::elements::word::{Word, WordMode};
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone, Default)]
 pub struct EvalLetParen {
@@ -15,8 +15,12 @@ pub struct EvalLetParen {
 }
 
 impl Subword for EvalLetParen {
-    fn get_text(&self) -> &str {&self.text.as_ref()}
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
 
     fn substitute(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
         self.connect_array(core)?;
@@ -26,7 +30,9 @@ impl Subword for EvalLetParen {
         Ok(())
     }
 
-    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)> {vec![]}
+    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)> {
+        vec![]
+    }
 
     /*
     fn make_glob_string(&mut self) -> String {
@@ -86,24 +92,36 @@ impl EvalLetParen {
         Ok(())
     }
 
-    fn eat_element(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore) -> Result<bool, ParseError> {
-        let sw: Box<dyn Subword> 
-            = if let Some(a) = BracedParam::parse(feeder, core)? {Box::new(a)}
-            else if let Some(a) = DoubleQuoted::parse(feeder, core, &None)? {Box::new(a)}
-            else if let Some(a) = Arithmetic::parse(feeder, core)? {Box::new(a)}
-            else if let Some(a) = CommandSubstitution::parse(feeder, core)? {Box::new(a)}
-            else if let Some(a) = Parameter::parse(feeder, core) {Box::new(a)}
-            else if let Some(a) = EscapedChar::parse(feeder, core){ Box::new(a) }
-            else if let Some(a) = Self::parse_name(feeder, core) { Box::new(a) }
-            else { return Ok(false) ; };
+    fn eat_element(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<bool, ParseError> {
+        let sw: Box<dyn Subword> = if let Some(a) = BracedParam::parse(feeder, core)? {
+            Box::new(a)
+        } else if let Some(a) = DoubleQuoted::parse(feeder, core, &None)? {
+            Box::new(a)
+        } else if let Some(a) = Arithmetic::parse(feeder, core)? {
+            Box::new(a)
+        } else if let Some(a) = CommandSubstitution::parse(feeder, core)? {
+            Box::new(a)
+        } else if let Some(a) = Parameter::parse(feeder, core) {
+            Box::new(a)
+        } else if let Some(a) = EscapedChar::parse(feeder, core) {
+            Box::new(a)
+        } else if let Some(a) = Self::parse_name(feeder, core) {
+            Box::new(a)
+        } else {
+            return Ok(false);
+        };
 
         ans.text += sw.get_text();
         ans.subwords.push(sw);
         Ok(true)
     }
-/*
+    /*
     fn parse_escaped_char(feeder: &mut Feeder) -> Option<EscapedChar> {
-        if feeder.starts_with("\\$") || feeder.starts_with("\\\\") 
+        if feeder.starts_with("\\$") || feeder.starts_with("\\\\")
         || feeder.starts_with("\\\"") || feeder.starts_with("\\`") {
             return Some(EscapedChar{ text: feeder.consume(2) });
         }
@@ -113,15 +131,20 @@ impl EvalLetParen {
     fn parse_name(feeder: &mut Feeder, core: &mut ShellCore) -> Option<VarName> {
         match feeder.scanner_name(core) {
             0 => None,
-            n => Some(VarName{ text: feeder.consume(n) }),
+            n => Some(VarName {
+                text: feeder.consume(n),
+            }),
         }
     }
 
-    fn eat_char(feeder: &mut Feeder, ans: &mut Self, core: &mut ShellCore)
-    -> Result<bool, ParseError> {
+    fn eat_char(
+        feeder: &mut Feeder,
+        ans: &mut Self,
+        core: &mut ShellCore,
+    ) -> Result<bool, ParseError> {
         if feeder.starts_with(")") {
             ans.text += &feeder.consume(1);
-            ans.subwords.push( From::from(")") );
+            ans.subwords.push(From::from(")"));
             return Ok(false);
         }
 
@@ -133,25 +156,29 @@ impl EvalLetParen {
 
         let ch = feeder.consume(len);
         ans.text += &ch.clone();
-        ans.subwords.push( From::from(&ch) );
+        ans.subwords.push(From::from(&ch));
         Ok(true)
     }
 
-    pub fn parse(feeder: &mut Feeder, core: &mut ShellCore,
-                 mode: &Option<WordMode>) -> Result<Option<Self>, ParseError> {
+    pub fn parse(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+        mode: &Option<WordMode>,
+    ) -> Result<Option<Self>, ParseError> {
         match mode {
-            Some(WordMode::EvalLet) => {},
+            Some(WordMode::EvalLet) => {}
             _ => return Ok(None),
         }
 
-        if ! feeder.starts_with("(") {
+        if !feeder.starts_with("(") {
             return Ok(None);
         }
 
         let mut ans = Self::default();
 
-        while Self::eat_element(feeder, &mut ans, core)?
-           || Self::eat_char(feeder, &mut ans, core)? {}
+        while Self::eat_element(feeder, &mut ans, core)? || Self::eat_char(feeder, &mut ans, core)?
+        {
+        }
 
         Ok(Some(ans))
     }

--- a/src/elements/subword/process_sub.rs
+++ b/src/elements/subword/process_sub.rs
@@ -1,14 +1,14 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
-use crate::elements::Pipe;
-use crate::elements::command::Command;
 use crate::elements::command::paren::ParenCommand;
+use crate::elements::command::Command;
 use crate::elements::subword::Subword;
 use crate::elements::word::WordMode;
-use crate::error::parse::ParseError;
+use crate::elements::Pipe;
 use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
 use nix::unistd;
 
 #[derive(Debug, Clone, Default)]
@@ -19,8 +19,12 @@ pub struct ProcessSubstitution {
 }
 
 impl Subword for ProcessSubstitution {
-    fn get_text(&self) -> &str {&self.text.as_ref()}
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
 
     fn substitute(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
         if self.direction != '<' {
@@ -36,13 +40,16 @@ impl Subword for ProcessSubstitution {
 }
 
 impl ProcessSubstitution {
-    pub fn parse(feeder: &mut Feeder, core: &mut ShellCore, mode: &Option<WordMode>)
-    -> Result<Option<Self>, ParseError> {
+    pub fn parse(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+        mode: &Option<WordMode>,
+    ) -> Result<Option<Self>, ParseError> {
         if let Some(WordMode::Arithmetric) = mode {
             return Ok(None);
         }
 
-        if ! feeder.starts_with("<(") && ! feeder.starts_with(">(") {
+        if !feeder.starts_with("<(") && !feeder.starts_with(">(") {
             return Ok(None);
         }
         let mut ans = ProcessSubstitution::default();

--- a/src/elements/subword/simple.rs
+++ b/src/elements/subword/simple.rs
@@ -1,8 +1,8 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::Feeder;
 use super::Subword;
+use crate::Feeder;
 
 #[derive(Debug, Clone)]
 pub struct SimpleSubword {
@@ -10,22 +10,34 @@ pub struct SimpleSubword {
 }
 
 impl Subword for SimpleSubword {
-    fn get_text(&self) -> &str {&self.text.as_ref()}
-    fn set_text(&mut self, text: &str) { self.text = text.to_string(); }
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
-    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)>{ vec![] }
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn set_text(&mut self, text: &str) {
+        self.text = text.to_string();
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
+    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)> {
+        vec![]
+    }
 }
 
 impl SimpleSubword {
     pub fn parse(feeder: &mut Feeder) -> Option<Self> {
         let len = feeder.scanner_subword_symbol();
         if len > 0 {
-            return Some( Self{ text :feeder.consume(len) } );
+            return Some(Self {
+                text: feeder.consume(len),
+            });
         }
 
         let len = feeder.scanner_subword();
         if len > 0 {
-            return Some( Self{ text :feeder.consume(len) } );
+            return Some(Self {
+                text: feeder.consume(len),
+            });
         }
 
         None

--- a/src/elements/subword/single_quoted.rs
+++ b/src/elements/subword/single_quoted.rs
@@ -1,8 +1,8 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
 use super::Subword;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone)]
 pub struct SingleQuoted {
@@ -10,22 +10,29 @@ pub struct SingleQuoted {
 }
 
 impl Subword for SingleQuoted {
-    fn get_text(&self) -> &str {&self.text}
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
+    fn get_text(&self) -> &str {
+        &self.text
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
 
     fn make_unquoted_string(&mut self) -> Option<String> {
-        Some( self.text[1..self.text.len()-1].to_string() )
+        Some(self.text[1..self.text.len() - 1].to_string())
     }
 
     fn make_glob_string(&mut self) -> String {
-        self.text[1..self.text.len()-1].replace("\\", "\\\\")
+        self.text[1..self.text.len() - 1]
+            .replace("\\", "\\\\")
             .replace("*", "\\*")
             .replace("?", "\\?")
             .replace("[", "\\[")
             .replace("]", "\\]")
     }
 
-    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)>{ vec![] }
+    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)> {
+        vec![]
+    }
 }
 
 impl SingleQuoted {
@@ -34,8 +41,8 @@ impl SingleQuoted {
             0 => None,
             n => {
                 let s = feeder.consume(n);
-                Some(SingleQuoted{ text: s })
-            },
+                Some(SingleQuoted { text: s })
+            }
         }
     }
 }

--- a/src/elements/subword/varname.rs
+++ b/src/elements/subword/varname.rs
@@ -1,8 +1,8 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{ShellCore, Feeder};
 use crate::elements::subword::Subword;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone)]
 pub struct VarName {
@@ -10,18 +10,30 @@ pub struct VarName {
 }
 
 impl Subword for VarName {
-    fn get_text(&self) -> &str {&self.text.as_ref()}
-    fn set_text(&mut self, text: &str) { self.text = text.to_string(); }
-    fn boxed_clone(&self) -> Box<dyn Subword> {Box::new(self.clone())}
-    fn is_name(&self) -> bool {true}
-    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)>{ vec![] }
+    fn get_text(&self) -> &str {
+        self.text.as_ref()
+    }
+    fn set_text(&mut self, text: &str) {
+        self.text = text.to_string();
+    }
+    fn boxed_clone(&self) -> Box<dyn Subword> {
+        Box::new(self.clone())
+    }
+    fn is_name(&self) -> bool {
+        true
+    }
+    fn split(&self, _: &str, _: Option<char>) -> Vec<(Box<dyn Subword>, bool)> {
+        vec![]
+    }
 }
 
 impl VarName {
     pub fn parse(feeder: &mut Feeder, core: &mut ShellCore) -> Option<Self> {
         match feeder.scanner_name(core) {
             0 => None,
-            n => Some( Self{ text: feeder.consume(n) } ),
+            n => Some(Self {
+                text: feeder.consume(n),
+            }),
         }
     }
 }

--- a/src/elements/word.rs
+++ b/src/elements/word.rs
@@ -2,17 +2,17 @@
 //SPDX-License-Identifier: BSD-3-Clause
 
 mod brace_expansion;
-pub mod tilde_expansion;
-pub mod substitution;
 pub mod path_expansion;
 mod split;
+pub mod substitution;
+pub mod tilde_expansion;
 
-use crate::{ShellCore, Feeder};
-use crate::elements::subword;
-use crate::elements::expr::arithmetic::ArithmeticExpr;
-use crate::error::parse::ParseError;
-use crate::error::exec::ExecError;
 use super::subword::Subword;
+use crate::elements::expr::arithmetic::ArithmeticExpr;
+use crate::elements::subword;
+use crate::error::exec::ExecError;
+use crate::error::parse::ParseError;
+use crate::{Feeder, ShellCore};
 
 #[derive(Debug, Clone)]
 pub enum WordMode {
@@ -44,8 +44,8 @@ impl From<&String> for Word {
     }
 }
 
-impl From<Box::<dyn Subword>> for Word {
-    fn from(subword: Box::<dyn Subword>) -> Self {
+impl From<Box<dyn Subword>> for Word {
+    fn from(subword: Box<dyn Subword>) -> Self {
         Self {
             text: subword.get_text().to_string(),
             subwords: vec![subword],
@@ -54,11 +54,11 @@ impl From<Box::<dyn Subword>> for Word {
     }
 }
 
-impl From<Vec<Box::<dyn Subword>>> for Word {
-    fn from(subwords: Vec<Box::<dyn Subword>>) -> Self {
+impl From<Vec<Box<dyn Subword>>> for Word {
+    fn from(subwords: Vec<Box<dyn Subword>>) -> Self {
         Self {
             text: subwords.iter().map(|s| s.get_text()).collect(),
-            subwords: subwords,
+            subwords,
             ..Default::default()
         }
     }
@@ -67,16 +67,16 @@ impl From<Vec<Box::<dyn Subword>>> for Word {
 impl Word {
     pub fn eval(&mut self, core: &mut ShellCore) -> Result<Vec<String>, ExecError> {
         let ws_after_brace_exp = match core.db.flags.contains('B') {
-            true  => brace_expansion::eval(&mut self.clone(), core.compat_bash),
+            true => brace_expansion::eval(&mut self.clone(), core.compat_bash),
             false => vec![self.clone()],
         };
 
         let mut ws = vec![];
         for w in ws_after_brace_exp {
             let expanded = w.tilde_and_dollar_expansion(core)?;
-            ws.append( &mut expanded.split_and_path_expansion(core) );
+            ws.append(&mut expanded.split_and_path_expansion(core));
         }
-        Ok( Self::make_args(&mut ws) )
+        Ok(Self::make_args(&mut ws))
     }
 
     pub fn eval_as_herestring(&self, core: &mut ShellCore) -> Result<String, ExecError> {
@@ -87,7 +87,7 @@ impl Word {
         let w = self.tilde_and_dollar_expansion(core)?;
         let mut ws = w.path_expansion(core);
         let joint = core.db.get_ifs_head();
-        Ok( Self::make_args(&mut ws).join(&joint) )
+        Ok(Self::make_args(&mut ws).join(&joint))
     }
 
     pub fn eval_as_integer(&self, core: &mut ShellCore) -> Result<String, ExecError> {
@@ -97,17 +97,17 @@ impl Word {
                 return a.eval(core);
             }
         }
- 
+
         Err(ExecError::SyntaxError(f.consume(f.len())))
     }
 
     pub fn eval_for_case_word(&self, core: &mut ShellCore) -> Option<String> {
         match self.tilde_and_dollar_expansion(core) {
             Ok(mut w) => w.make_unquoted_word(),
-            Err(e)    => {
+            Err(e) => {
                 e.print(core);
-                return None;
-            },
+                None
+            }
         }
     }
 
@@ -123,11 +123,11 @@ impl Word {
                 }
 
                 Some(re)
-            },
-            Err(e)    => {
+            }
+            Err(e) => {
                 e.print(core);
-                return None;
-            },
+                None
+            }
         }
     }
 
@@ -149,20 +149,20 @@ impl Word {
 
         let len = splitted.len();
         if len > 0 {
-            splitted[len-1].do_not_erase = false;
+            splitted[len - 1].do_not_erase = false;
         }
-        
+
         if core.options.query("noglob") {
             return splitted;
         }
 
         for mut w in splitted {
-            ans.append(&mut path_expansion::eval(&mut w, &core.shopts) );
+            ans.append(&mut path_expansion::eval(&mut w, &core.shopts));
         }
         ans
     }
 
-   fn path_expansion(&self, core: &mut ShellCore) -> Vec<Word> {
+    fn path_expansion(&self, core: &mut ShellCore) -> Vec<Word> {
         if core.options.query("noglob") {
             return vec![self.clone()];
         }
@@ -170,19 +170,22 @@ impl Word {
         path_expansion::eval(&mut self.clone(), &core.shopts)
     }
 
-    fn make_args(words: &mut Vec<Word>) -> Vec<String> {
-        words.iter_mut()
-              .filter_map(|w| w.make_unquoted_word())
-              .collect()
+    fn make_args(words: &mut [Word]) -> Vec<String> {
+        words
+            .iter_mut()
+            .filter_map(|w| w.make_unquoted_word())
+            .collect()
     }
 
     pub fn make_unquoted_word(&mut self) -> Option<String> {
-        let sw: Vec<Option<String>> = self.subwords.iter_mut()
+        let sw: Vec<Option<String>> = self
+            .subwords
+            .iter_mut()
             .map(|s| s.make_unquoted_string())
-            .filter(|s| *s != None)
+            .filter(|s| s.is_some())
             .collect();
 
-        if sw.is_empty() && ! self.do_not_erase {
+        if sw.is_empty() && !self.do_not_erase {
             return None;
         }
 
@@ -190,9 +193,11 @@ impl Word {
     }
 
     pub fn make_regex(&mut self) -> Option<String> {
-        let sw: Vec<Option<String>> = self.subwords.iter_mut()
+        let sw: Vec<Option<String>> = self
+            .subwords
+            .iter_mut()
             .map(|s| s.make_regex())
-            .filter(|s| *s != None)
+            .filter(|s| s.is_some())
             .collect();
 
         if sw.is_empty() {
@@ -203,7 +208,8 @@ impl Word {
     }
 
     fn make_glob_string(&mut self) -> String {
-        self.subwords.iter_mut()
+        self.subwords
+            .iter_mut()
             .map(|s| s.make_glob_string())
             .collect::<Vec<String>>()
             .concat()
@@ -214,21 +220,21 @@ impl Word {
     }
 
     fn scan_pos(&self, s: &str) -> Vec<usize> {
-        self.subwords.iter()
+        self.subwords
+            .iter()
             .enumerate()
             .filter(|e| e.1.get_text() == s)
             .map(|e| e.0)
             .collect()
     }
 
-    fn push(&mut self, subword: &Box<dyn Subword>) {
-        self.text += &subword.get_text().to_string();
-        self.subwords.push(subword.clone());
+    fn push(&mut self, subword: &dyn Subword) {
+        self.text += subword.get_text();
+        self.subwords.push(subword.boxed_clone());
     }
 
     fn pre_check(feeder: &mut Feeder, mode: &Option<WordMode>) -> bool {
-        if feeder.starts_with("#") && mode.is_none() 
-        || feeder.is_empty() {
+        if feeder.starts_with("#") && mode.is_none() || feeder.is_empty() {
             return false;
         }
 
@@ -237,43 +243,44 @@ impl Word {
                 if feeder.starts_with("}") {
                     return false;
                 }
-            },
+            }
             Some(WordMode::ParamOption(ref v)) => {
                 if feeder.starts_withs2(v) {
                     return false;
                 }
             }
-            _ => {},
+            _ => {}
         }
         true
     }
 
-    fn post_check(feeder: &mut Feeder, core: &mut ShellCore,
-                  mode: &Option<WordMode>) -> bool {
-        if feeder.len() == 0 {
+    fn post_check(feeder: &mut Feeder, core: &mut ShellCore, mode: &Option<WordMode>) -> bool {
+        if feeder.is_empty() {
             return false;
         }
 
         match mode {
             Some(WordMode::Arithmetric) | Some(WordMode::CompgenF) => {
-                if feeder.starts_withs(&["]", "}"]) 
-                || feeder.scanner_math_symbol(core) != 0 {
+                if feeder.starts_withs(&["]", "}"]) || feeder.scanner_math_symbol(core) != 0 {
                     return false;
                 }
-            },
+            }
             Some(WordMode::ParamOption(ref v)) => {
                 if feeder.starts_withs2(v) {
                     return false;
                 }
             }
-            _ => {},
+            _ => {}
         }
         true
     }
 
-    pub fn parse(feeder: &mut Feeder, core: &mut ShellCore, mode: Option<WordMode>)
-    -> Result<Option<Word>, ParseError> {
-        if ! Self::pre_check(feeder, &mode) {
+    pub fn parse(
+        feeder: &mut Feeder,
+        core: &mut ShellCore,
+        mode: Option<WordMode>,
+    ) -> Result<Option<Word>, ParseError> {
+        if !Self::pre_check(feeder, &mode) {
             return Ok(None);
         }
 
@@ -285,14 +292,14 @@ impl Word {
 
         while let Some(sw) = subword::parse(feeder, core, &mode)? {
             match sw.is_extglob() {
-                false => ans.push(&sw),
-                true  => {
-                    ans.text += &sw.get_text();
+                false => ans.push(sw.as_ref()),
+                true => {
+                    ans.text += sw.get_text();
                     ans.subwords.append(&mut sw.get_child_subwords());
-                },
+                }
             }
 
-            if ! Self::post_check(feeder, core, &mode) {
+            if !Self::post_check(feeder, core, &mode) {
                 break;
             }
         }

--- a/src/elements/word/brace_expansion.rs
+++ b/src/elements/word/brace_expansion.rs
@@ -1,9 +1,9 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
+use crate::elements::subword::single_quoted::SingleQuoted;
 use crate::elements::subword::Subword;
 use crate::elements::word::Word;
-use crate::elements::subword::single_quoted::SingleQuoted;
 
 enum BraceType {
     Comma,
@@ -15,20 +15,29 @@ fn after_dollar(s: &str) -> bool {
 }
 
 fn num_to_subword(n: i128) -> Box<dyn Subword> {
-    Box::new( SingleQuoted { text: format!("'{}'", n)  } )
+    Box::new(SingleQuoted {
+        text: format!("'{n}'"),
+    })
 }
 
 fn ascii_to_subword(c: char) -> Box<dyn Subword> {
-    let table = vec!["^?", "\\M-^@", "\\M-^A", "\\M-^B", "\\M-^C", "\\M-^D", "\\M-^E", "\\M-^F", "\\M-^G", "\\M-^H", "\\M-\t", "\\M-\n", "\\M-^K", "\\M-^L", "\\M-^M", "\\M-^N", "\\M-^O", "\\M-^P", "\\M-^Q", "\\M-^R", "\\M-^S", "\\M-^T", "\\M-^U", "\\M-^V", "\\M-^W", "\\M-^X", "\\M-^Y", "\\M-^Z", "\\M-^[", "\\M-^\\", "\\M-^]", "\\M-^^", "\\M-^_", " ", "¡"];
+    let table = vec![
+        "^?", "\\M-^@", "\\M-^A", "\\M-^B", "\\M-^C", "\\M-^D", "\\M-^E", "\\M-^F", "\\M-^G",
+        "\\M-^H", "\\M-\t", "\\M-\n", "\\M-^K", "\\M-^L", "\\M-^M", "\\M-^N", "\\M-^O", "\\M-^P",
+        "\\M-^Q", "\\M-^R", "\\M-^S", "\\M-^T", "\\M-^U", "\\M-^V", "\\M-^W", "\\M-^X", "\\M-^Y",
+        "\\M-^Z", "\\M-^[", "\\M-^\\", "\\M-^]", "\\M-^^", "\\M-^_", " ", "¡",
+    ];
 
     let n = c as usize;
     let text = if n >= 127 && n < 127 + table.len() {
-        table[n-127].to_string()
-    }else{
+        table[n - 127].to_string()
+    } else {
         c.to_string()
     };
 
-    Box::new( SingleQuoted { text: format!("'{}'", text)  } )
+    Box::new(SingleQuoted {
+        text: format!("'{text}'"),
+    })
 }
 
 fn connect_minus(subwords: &mut Vec<Box<dyn Subword>>) {
@@ -44,26 +53,26 @@ fn connect_minus(subwords: &mut Vec<Box<dyn Subword>>) {
     }
 
     for i in pos {
-        if i+1 < subwords.len() {
+        if i + 1 < subwords.len() {
             let mut num = true;
-            for ch in subwords[i+1].get_text().chars() {
-                if ch < '0' || '9' < ch {
+            for ch in subwords[i + 1].get_text().chars() {
+                if !ch.is_ascii_digit() {
                     num = false;
                     break;
                 }
             }
 
-            if ! num {
+            if !num {
                 continue;
             }
 
             subwords[i] = Default::default();
-            let m_str = "-".to_owned() + subwords[i+1].get_text();
-            subwords[i+1] = From::from(&m_str);
+            let m_str = "-".to_owned() + subwords[i + 1].get_text();
+            subwords[i + 1] = From::from(&m_str);
         }
     }
 
-    subwords.retain(|e| e.get_text().len() != 0);
+    subwords.retain(|e| !e.get_text().is_empty());
 }
 
 pub fn eval(word: &mut Word, compat_bash: bool) -> Vec<Word> {
@@ -72,22 +81,25 @@ pub fn eval(word: &mut Word, compat_bash: bool) -> Vec<Word> {
 
     let mut skip_until = 0;
     for i in word.scan_pos("{") {
-        if i < skip_until { //ブレース展開の終わりまで処理をスキップ
-             continue;
+        if i < skip_until {
+            //ブレース展開の終わりまで処理をスキップ
+            continue;
         }
 
         if let Some(d) = parse(&word.subwords[i..]) {
-            let shift_d: Vec<usize> = d.0.iter().map(|e| e+i).collect();
+            let shift_d: Vec<usize> = d.0.iter().map(|e| e + i).collect();
 
-            if i > 0 && after_dollar(word.subwords[i-1].get_text()) {
+            if i > 0 && after_dollar(word.subwords[i - 1].get_text()) {
                 skip_until = *shift_d.last().unwrap();
                 continue;
             }
 
             return match d.1 {
                 BraceType::Comma => expand_comma_brace(&word.subwords, &shift_d, compat_bash),
-                BraceType::Range(n) => expand_range_brace(&mut word.subwords, &shift_d, n, compat_bash),
-            }
+                BraceType::Range(n) => {
+                    expand_range_brace(&mut word.subwords, &shift_d, n, compat_bash)
+                }
+            };
         }
     }
 
@@ -99,8 +111,7 @@ fn invalidate_brace(subwords: &mut Vec<Box<dyn Subword>>) {
         return;
     }
 
-    if subwords[0].get_text() == "{"
-    && subwords[1].get_text() == "}" {
+    if subwords[0].get_text() == "{" && subwords[1].get_text() == "}" {
         subwords.remove(1);
         subwords[0].set_text("{}");
     }
@@ -111,58 +122,61 @@ fn parse(subwords: &[Box<dyn Subword>]) -> Option<(Vec<usize>, BraceType)> {
     for sw in subwords {
         stack.push(Some(sw.get_text()));
         if sw.get_text() == "}" {
-            match get_delimiters(&mut stack) {
-                Some(found) => return Some(found),
-                _           => {},
+            if let Some(found) = get_delimiters(&mut stack) {
+                return Some(found);
             }
         }
     }
     None
 }
 
-fn get_delimiters(stack: &mut Vec<Option<&str>>) -> Option<(Vec<usize>, BraceType)> {
+fn get_delimiters(stack: &mut [Option<&str>]) -> Option<(Vec<usize>, BraceType)> {
     let mut comma_pos = vec![];
     let mut period_pos = vec![];
 
-    for i in (1..stack.len()-1).rev() {
+    for i in (1..stack.len() - 1).rev() {
         if stack[i] == Some(",") {
             comma_pos.push(i);
         } else if stack[i] == Some(".") {
             period_pos.push(i);
-        }else if stack[i] == Some("{") { // find an inner brace expcomma_posion
+        } else if stack[i] == Some("{") {
+            // find an inner brace expcomma_posion
             stack[i..].iter_mut().for_each(|e| *e = None);
             return None;
         }
     }
 
-    if comma_pos.len() > 0 {
+    if !comma_pos.is_empty() {
         comma_pos.reverse();
         comma_pos.insert(0, 0); // add "{" pos
-        comma_pos.push(stack.len()-1); // add "}" pos
-        return Some( (comma_pos, BraceType::Comma) );
+        comma_pos.push(stack.len() - 1); // add "}" pos
+        return Some((comma_pos, BraceType::Comma));
     }
 
     if period_pos.len() == 2 && period_pos[0] == period_pos[1] + 1 {
         period_pos.reverse();
         period_pos.insert(0, 0);
-        period_pos.push(stack.len()-1);
-        return Some( (period_pos, BraceType::Range(2)) );
+        period_pos.push(stack.len() - 1);
+        return Some((period_pos, BraceType::Range(2)));
     }
 
-    if period_pos.len() == 4 
-    && period_pos[0] == period_pos[1] + 1 
-    && period_pos[2] == period_pos[3] + 1 {
+    if period_pos.len() == 4
+        && period_pos[0] == period_pos[1] + 1
+        && period_pos[2] == period_pos[3] + 1
+    {
         period_pos.reverse();
         period_pos.insert(0, 0);
-        period_pos.push(stack.len()-1);
-        return Some( (period_pos, BraceType::Range(3)) );
+        period_pos.push(stack.len() - 1);
+        return Some((period_pos, BraceType::Range(3)));
     }
 
     None
 }
 
-fn comma_brace_to_subwords(subwords: &Vec<Box<dyn Subword>>, delimiters: &Vec<usize>)
-                           -> Vec<Vec<Box<dyn Subword>>> {
+fn comma_brace_to_subwords(
+    subwords: &[Box<dyn Subword>],
+    delimiters: &[usize],
+) -> Vec<Vec<Box<dyn Subword>>> {
     let mut ans = vec![];
     let mut from = delimiters[0] + 1;
     for to in &delimiters[1..] {
@@ -172,35 +186,42 @@ fn comma_brace_to_subwords(subwords: &Vec<Box<dyn Subword>>, delimiters: &Vec<us
     ans
 }
 
-fn expand_comma_brace(subwords: &Vec<Box<dyn Subword>>,
-    delimiters: &Vec<usize>, compat_bash: bool) -> Vec<Word> {
+fn expand_comma_brace(
+    subwords: &[Box<dyn Subword>],
+    delimiters: &[usize],
+    compat_bash: bool,
+) -> Vec<Word> {
     let left = subwords[..delimiters[0]].to_vec();
-    let mut right = subwords[(delimiters.last().unwrap()+1)..].to_vec();
+    let mut right = subwords[(delimiters.last().unwrap() + 1)..].to_vec();
     invalidate_brace(&mut right);
 
     let sws = comma_brace_to_subwords(subwords, delimiters);
     subword_sets_to_words(&sws, &left, &right, compat_bash)
 }
 
-fn expand_range_brace(subwords: &mut Vec<Box<dyn Subword>>, delimiters: &Vec<usize>,
-    operand_num: usize, compat_bash: bool)-> Vec<Word> {
-    let start_wrap = subwords[delimiters[0]+1].make_unquoted_string(); // right of {
-    let end_wrap = subwords[delimiters[2]+1].make_unquoted_string(); // left of }
-    
+fn expand_range_brace(
+    subwords: &mut Vec<Box<dyn Subword>>,
+    delimiters: &[usize],
+    operand_num: usize,
+    compat_bash: bool,
+) -> Vec<Word> {
+    let start_wrap = subwords[delimiters[0] + 1].make_unquoted_string(); // right of {
+    let end_wrap = subwords[delimiters[2] + 1].make_unquoted_string(); // left of }
+
     let (start, end) = match (start_wrap, end_wrap) {
-        ( Some(s), Some(e) ) => (s, e),
+        (Some(s), Some(e)) => (s, e),
         _ => return subwords_to_word(subwords),
     };
 
     let mut skip_num = match operand_num {
         2 => 1,
         3 => {
-            let skip = subwords[delimiters[4]+1].get_text();
+            let skip = subwords[delimiters[4] + 1].get_text();
             match skip.parse::<i32>() {
-                Ok(n) => n.abs() as usize,
+                Ok(n) => n.unsigned_abs() as usize,
                 _ => return subwords_to_word(subwords),
             }
-        },
+        }
         _ => return subwords_to_word(subwords),
     };
     skip_num = std::cmp::max(skip_num, 1);
@@ -216,7 +237,9 @@ fn expand_range_brace(subwords: &mut Vec<Box<dyn Subword>>, delimiters: &Vec<usi
     if compat_bash {
         for e in series.iter_mut() {
             if e.get_text() == "'\\'" {
-                *e = Box::new( SingleQuoted { text: "''".to_string()  } );
+                *e = Box::new(SingleQuoted {
+                    text: "''".to_string(),
+                });
             }
         }
     }
@@ -227,31 +250,35 @@ fn expand_range_brace(subwords: &mut Vec<Box<dyn Subword>>, delimiters: &Vec<usi
     }
 
     let left = &subwords[..delimiters[0]];
-    let mut right = subwords[(delimiters.last().unwrap()+1)..].to_vec();
+    let mut right = subwords[(delimiters.last().unwrap() + 1)..].to_vec();
     invalidate_brace(&mut right);
 
     subword_sets_to_words(&series2, left, &right, compat_bash)
 }
 
 fn gen_nums(start: &str, end: &str, skip: usize) -> Vec<Box<dyn Subword>> {
-    let (start_num, end_num) = match (start.parse::<i128>(), end.parse::<i128>() ) {
-        ( Ok(s), Ok(e) ) => (s, e),
+    let (start_num, end_num) = match (start.parse::<i128>(), end.parse::<i128>()) {
+        (Ok(s), Ok(e)) => (s, e),
         _ => return vec![],
     };
 
     let min = std::cmp::min(start_num, end_num);
     let max = std::cmp::max(start_num, end_num);
 
-    let mut ans: Vec<Box<dyn Subword>> = (min..(max+1)).map(|n| num_to_subword(n) ).collect();
+    let mut ans: Vec<Box<dyn Subword>> = (min..(max + 1)).map(|n| num_to_subword(n)).collect();
     if start_num > end_num {
         ans.reverse();
     }
-    ans.into_iter().enumerate().filter(|e| e.0%skip == 0).map(|e| e.1).collect() 
+    ans.into_iter()
+        .enumerate()
+        .filter(|e| e.0 % skip == 0)
+        .map(|e| e.1)
+        .collect()
 }
 
 fn gen_chars(start: &str, end: &str, skip: usize, compat_bash: bool) -> Vec<Box<dyn Subword>> {
-    let (start_num, end_num) = match (start.chars().nth(0), end.chars().nth(0) ) {
-        ( Some(s), Some(e) ) => (s, e),
+    let (start_num, end_num) = match (start.chars().next(), end.chars().next()) {
+        (Some(s), Some(e)) => (s, e),
         _ => return vec![],
     };
 
@@ -263,29 +290,37 @@ fn gen_chars(start: &str, end: &str, skip: usize, compat_bash: bool) -> Vec<Box<
     let max = std::cmp::max(start_num, end_num);
 
     if compat_bash {
-        if ('0' <= min && min <= '9') && ! ('0' <= max && max <= '9') {
+        if min.is_ascii_digit() && !max.is_ascii_digit() {
             return vec![];
         }
-        if ('0' <= max && max <= '9') && ! ('0' <= min && min <= '9') {
+        if max.is_ascii_digit() && !min.is_ascii_digit() {
             return vec![];
         }
     }
 
-    let mut ans: Vec<Box<dyn Subword>> = (min..max).map(|n| ascii_to_subword(n) ).collect();
-    ans.push( ascii_to_subword(max) );
+    let mut ans: Vec<Box<dyn Subword>> = (min..max).map(|n| ascii_to_subword(n)).collect();
+    ans.push(ascii_to_subword(max));
     if start_num > end_num {
         ans.reverse();
     }
 
-    ans.into_iter().enumerate().filter(|e| e.0%skip == 0).map(|e| e.1).collect() 
+    ans.into_iter()
+        .enumerate()
+        .filter(|e| e.0 % skip == 0)
+        .map(|e| e.1)
+        .collect()
 }
 
-fn subword_sets_to_words(series: &Vec<Vec<Box<dyn Subword>>>, 
-    left: &[Box<dyn Subword>], right: &[Box<dyn Subword>], compat_bash: bool) -> Vec<Word> {
+fn subword_sets_to_words(
+    series: &Vec<Vec<Box<dyn Subword>>>,
+    left: &[Box<dyn Subword>],
+    right: &[Box<dyn Subword>],
+    compat_bash: bool,
+) -> Vec<Word> {
     let mut ws = vec![];
     for sws in series {
         let mut w = Word::default();
-        w.subwords = [ left, sws, right ].concat();
+        w.subwords = [left, sws, right].concat();
         w.text = w.subwords.iter().map(|s| s.get_text()).collect();
         ws.push(w);
     }

--- a/src/elements/word/path_expansion.rs
+++ b/src/elements/word/path_expansion.rs
@@ -19,21 +19,22 @@ pub fn eval(word: &mut Word, shopts: &Options) -> Vec<Word> {
         return vec![word.clone()];
     }
 
-    paths.iter().map(|p| From::from(p) ).collect()
+    paths.iter().map(From::from).collect()
 }
 
 fn no_glob_symbol(pattern: &str) -> bool {
-    "*?@+![".chars().all(|c| ! pattern.contains(c))
+    "*?@+![".chars().all(|c| !pattern.contains(c))
 }
 
 pub fn expand(pattern: &str, shopts: &Options) -> Vec<String> {
     let mut paths = vec!["".to_string()];
 
     for dir_glob in pattern.split("/") {
-        let mut tmp = paths.iter()
-                .map(|c| directory::glob(&c, &dir_glob, shopts) )
-                .collect::<Vec<Vec<String>>>()
-                .concat();
+        let mut tmp = paths
+            .iter()
+            .map(|c| directory::glob(c, dir_glob, shopts))
+            .collect::<Vec<Vec<String>>>()
+            .concat();
 
         if dir_glob == "**" && shopts.query("globstar") {
             tmp.append(&mut paths);
@@ -44,11 +45,17 @@ pub fn expand(pattern: &str, shopts: &Options) -> Vec<String> {
         paths.dedup();
     }
 
-    paths.iter_mut().for_each(|e| {e.pop();} );
+    paths.iter_mut().for_each(|e| {
+        e.pop();
+    });
 
     if shopts.query("globstar") {
         if let Some(ptn) = pattern.strip_suffix("/**") {
-            paths.iter_mut().for_each(|p| if p == ptn {*p += "/";} );
+            paths.iter_mut().for_each(|p| {
+                if p == ptn {
+                    *p += "/";
+                }
+            });
         }
     }
 

--- a/src/elements/word/split.rs
+++ b/src/elements/word/split.rs
@@ -1,12 +1,14 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
-use crate::elements::word::Word;
 use crate::elements::subword::Subword;
+use crate::elements::word::Word;
+use crate::ShellCore;
+
+type SplitResult = (usize, Vec<(Box<dyn Subword>, bool)>);
 
 pub fn eval(word: &Word, core: &mut ShellCore) -> Vec<Word> {
-    if ! core.db.has_value("IFS") {
+    if !core.db.has_value("IFS") {
         let _ = core.db.set_param("IFS", " \t\n", None);
     }
 
@@ -28,10 +30,10 @@ pub fn eval(word: &Word, core: &mut ShellCore) -> Vec<Word> {
     }
 
     let remain = split[0].1;
-    let mut right = gen_word(word.subwords[pos+1..].to_vec(), remain);
+    let mut right = gen_word(word.subwords[pos + 1..].to_vec(), remain);
     right.subwords.insert(0, split.remove(0).0);
 
-    [ ans, eval(&right, core) ].concat()
+    [ans, eval(&right, core)].concat()
 }
 
 fn gen_word(sws: Vec<Box<dyn Subword>>, remain: bool) -> Word {
@@ -42,7 +44,7 @@ fn gen_word(sws: Vec<Box<dyn Subword>>, remain: bool) -> Word {
     }
 }
 
-pub fn find_pos(word: &Word, ifs: &str) -> (usize, Vec<(Box<dyn Subword>, bool)>) {
+pub fn find_pos(word: &Word, ifs: &str) -> SplitResult {
     let mut prev_char = None;
     for (i, sw) in word.subwords.iter().enumerate() {
         let split = sw.split(ifs, prev_char);
@@ -50,7 +52,7 @@ pub fn find_pos(word: &Word, ifs: &str) -> (usize, Vec<(Box<dyn Subword>, bool)>
             return (i, split);
         }
 
-        if ! sw.get_text().is_empty() {
+        if !sw.get_text().is_empty() {
             prev_char = sw.get_text().chars().last();
         }
     }

--- a/src/elements/word/substitution.rs
+++ b/src/elements/word/substitution.rs
@@ -1,11 +1,11 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
-use crate::error::exec::ExecError;
-use crate::elements::word::Word;
-use crate::elements::subword::Subword;
 use crate::elements::subword::parameter::Parameter;
+use crate::elements::subword::Subword;
+use crate::elements::word::Word;
+use crate::error::exec::ExecError;
+use crate::ShellCore;
 
 pub fn eval(word: &mut Word, core: &mut ShellCore) -> Result<(), ExecError> {
     for i in word.scan_pos("$") {
@@ -16,13 +16,18 @@ pub fn eval(word: &mut Word, core: &mut ShellCore) -> Result<(), ExecError> {
         w.substitute(core)?;
         let mut new_objs = w.alter()?;
         match new_objs.is_empty() {
-            true  => tmp.push(w.clone()),
+            true => tmp.push(w.clone()),
             false => tmp.append(&mut new_objs),
         }
     }
 
     word.subwords = tmp;
-    word.text = word.subwords.iter().map(|sw| sw.get_text().to_string()).collect::<Vec<String>>().join("");
+    word.text = word
+        .subwords
+        .iter()
+        .map(|sw| sw.get_text().to_string())
+        .collect::<Vec<String>>()
+        .join("");
     Ok(())
 }
 
@@ -30,7 +35,7 @@ fn connect_names(subwords: &mut [Box<dyn Subword>]) {
     let mut text = "$".to_string();
     let mut pos = 1;
     for s in &mut subwords[1..] {
-        if ! s.is_name() {
+        if !s.is_name() {
             break;
         }
         text += s.get_text();
@@ -38,8 +43,10 @@ fn connect_names(subwords: &mut [Box<dyn Subword>]) {
     }
 
     if pos > 1 {
-        let mut sw = Parameter::default();
-        sw.text = text;
+        let sw = Parameter {
+            text,
+            ..Default::default()
+        };
         subwords[0] = Box::new(sw);
         subwords[1..pos].iter_mut().for_each(|s| s.set_text(""));
     }

--- a/src/elements/word/tilde_expansion.rs
+++ b/src/elements/word/tilde_expansion.rs
@@ -1,17 +1,18 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
-use crate::error::exec::ExecError;
 use crate::elements::word::Word;
+use crate::error::exec::ExecError;
+use crate::ShellCore;
 //use crate::elements::subword::Subword;
-use nix::unistd::User;
 use super::WordMode;
+use nix::unistd::User;
 
 pub fn eval(word: &mut Word, core: &mut ShellCore) {
-    if word.subwords.len() > 1 
-    && word.subwords[1..].iter().any(|sw| sw.get_text() == "=") 
-    && ! core.options.query("posix") {
+    if word.subwords.len() > 1
+        && word.subwords[1..].iter().any(|sw| sw.get_text() == "=")
+        && !core.options.query("posix")
+    {
         return eval_multi(word, core);
     }
     if let Some(WordMode::RightOfSubstitution) = word.mode {
@@ -27,18 +28,21 @@ fn eval_single(word: &mut Word, core: &mut ShellCore) {
         n => n,
     };
 
-    let text: String = word.subwords[1..length].iter()
-               .map(|e| e.get_text().to_string())
-               .collect::<Vec<String>>()
-               .concat();
+    let text: String = word.subwords[1..length]
+        .iter()
+        .map(|e| e.get_text().to_string())
+        .collect::<Vec<String>>()
+        .concat();
 
-    let value = get_value(&text, core).unwrap_or(String::new());
-    if value == "" {
+    let value = get_value(&text, core).unwrap_or_default();
+    if value.is_empty() {
         return;
     }
     word.text = value.clone();
     word.subwords[0] = From::from(&value);
-    word.subwords[1..length].iter_mut().for_each(|w| w.set_text(""));
+    word.subwords[1..length]
+        .iter_mut()
+        .for_each(|w| w.set_text(""));
 }
 
 pub fn eval_multi(word: &mut Word, core: &mut ShellCore) {
@@ -50,29 +54,30 @@ pub fn eval_multi(word: &mut Word, core: &mut ShellCore) {
             equal += 1;
         }
 
-        if sw.get_text() == ":" 
-        || (sw.get_text() == "=" && equal < 2) {
+        if sw.get_text() == ":" || (sw.get_text() == "=" && equal < 2) {
             let mut w = Word::from(tmp.clone());
             eval_single(&mut w, core);
             ans_sws.append(&mut w.subwords);
             tmp.clear();
             ans_sws.push(sw.clone());
-        }else{
+        } else {
             tmp.push(sw.clone());
         }
     }
 
-    if ! tmp.is_empty() {
+    if !tmp.is_empty() {
         let mut w = Word::from(tmp.clone());
         eval_single(&mut w, core);
         ans_sws.append(&mut w.subwords);
     }
 
     word.subwords = ans_sws;
-    word.text = word.subwords.iter()
-               .map(|e| e.get_text().to_string())
-               .collect::<Vec<String>>()
-               .concat();
+    word.text = word
+        .subwords
+        .iter()
+        .map(|e| e.get_text().to_string())
+        .collect::<Vec<String>>()
+        .concat();
 }
 
 fn prefix_length(word: &Word) -> usize {
@@ -81,7 +86,7 @@ fn prefix_length(word: &Word) -> usize {
     }
 
     match word.subwords.iter().position(|e| e.get_text() == "/") {
-        None    => word.subwords.len(),
+        None => word.subwords.len(),
         Some(n) => n,
     }
 }
@@ -99,10 +104,7 @@ fn get_value(text: &str, core: &mut ShellCore) -> Result<String, ExecError> {
 
 fn get_home_dir(user: &str) -> String {
     match User::from_name(user) {
-        Ok(Some(u)) => u.dir
-                        .into_os_string()
-                        .into_string()
-                        .unwrap(),
+        Ok(Some(u)) => u.dir.into_os_string().into_string().unwrap(),
         _ => String::new(),
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,25 +14,25 @@ pub fn print(s: &str, core: &mut ShellCore) {
     let name = core.db.get_param("0").unwrap();
     if core.db.flags.contains('i') {
         eprintln!("{}: {}", &name, &s);
-    }else{
+    } else {
         let lineno = core.db.get_param("LINENO").unwrap_or("".to_string());
         eprintln!("{}: line {}: {}", &name, &lineno, s);
     }
 }
 
 pub fn internal(s: &str) -> String {
-    format!("SUSH INTERNAL ERROR: {}", s)
+    format!("SUSH INTERNAL ERROR: {s}")
 }
 
 pub fn exponent(s: &str) -> String {
-    format!("exponent less than 0 (error token is \"{}\")", s)
+    format!("exponent less than 0 (error token is \"{s}\")")
 }
 
 /* error at wait */
 pub fn signaled(pid: Pid, signal: Signal, coredump: bool) -> i32 {
     match coredump {
-        true  => eprintln!("Pid: {:?}, Signal: {:?} (core dumped)", pid, signal),
-        false => eprintln!("Pid: {:?}, Signal: {:?}", pid, signal),
+        true => eprintln!("Pid: {pid:?}, Signal: {signal:?} (core dumped)"),
+        false => eprintln!("Pid: {pid:?}, Signal: {signal:?}"),
     }
-    128+signal as i32
+    128 + signal as i32
 }

--- a/src/error/arith.rs
+++ b/src/error/arith.rs
@@ -27,36 +27,29 @@ impl From<ArithError> for String {
 impl From<&ArithError> for String {
     fn from(e: &ArithError) -> String {
         match e {
-            ArithError::AssignmentToNonVariable(right)
-                => error_msg("attempted assignment to non-variable", right),
-            ArithError::DivZero(token)
-                => error_msg("division by 0", token),
-            ArithError::Exponent(s)
-                => error_msg("exponent less than 0", &s.to_string()),
-            ArithError::NoColon(token)
-                => error_msg("`:' expected for conditional expression", token),
-            ArithError::ExpressionExpected(token)
-                => error_msg("expression expected", token),
-            ArithError::InvalidBase(b)
-                => error_msg("invalid arithmetic base", b),
-            ArithError::ValueTooGreatForBase(num)
-                => error_msg("value too great for base", num),
-            ArithError::InvalidNumber(name)
-                => error_msg("invalid number", name),
-            ArithError::InvalidIntConst(tok)
-                => error_msg("invalid integer constant", tok),
-            ArithError::InvalidOperator(tok)
-                => error_msg("invalid arithmetic operator", tok),
-            ArithError::OperandExpected(token)
-                => error_msg("syntax error: operand expected", token),
-            ArithError::Recursion(token)
-                => error_msg("expression recursion level exceeded", token), 
-            ArithError::SyntaxError(token)
-                => error_msg("syntax error in expression", token),
+            ArithError::AssignmentToNonVariable(right) => {
+                error_msg("attempted assignment to non-variable", right)
+            }
+            ArithError::DivZero(token) => error_msg("division by 0", token),
+            ArithError::Exponent(s) => error_msg("exponent less than 0", &s.to_string()),
+            ArithError::NoColon(token) => {
+                error_msg("`:' expected for conditional expression", token)
+            }
+            ArithError::ExpressionExpected(token) => error_msg("expression expected", token),
+            ArithError::InvalidBase(b) => error_msg("invalid arithmetic base", b),
+            ArithError::ValueTooGreatForBase(num) => error_msg("value too great for base", num),
+            ArithError::InvalidNumber(name) => error_msg("invalid number", name),
+            ArithError::InvalidIntConst(tok) => error_msg("invalid integer constant", tok),
+            ArithError::InvalidOperator(tok) => error_msg("invalid arithmetic operator", tok),
+            ArithError::OperandExpected(token) => {
+                error_msg("syntax error: operand expected", token)
+            }
+            ArithError::Recursion(token) => error_msg("expression recursion level exceeded", token),
+            ArithError::SyntaxError(token) => error_msg("syntax error in expression", token),
         }
     }
 }
 
 fn error_msg(msg: &str, token: &str) -> String {
-    msg.to_string() + &format!(" (error token is \"{}\")", token)
+    msg.to_string() + &format!(" (error token is \"{token}\")")
 }

--- a/src/error/exec.rs
+++ b/src/error/exec.rs
@@ -1,9 +1,9 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
 use crate::error::arith::ArithError;
 use crate::error::parse::ParseError;
+use crate::ShellCore;
 use nix::errno::Errno;
 use nix::sys::wait::WaitStatus;
 use std::num::ParseIntError;
@@ -71,28 +71,32 @@ impl From<&ExecError> for String {
     fn from(e: &ExecError) -> String {
         match e {
             ExecError::Internal => "INTERNAL ERROR".to_string(),
-            ExecError::AmbiguousRedirect(name) => format!("{}: ambiguous redirect", name),
-            ExecError::ArrayIndexInvalid(name) => format!("`{}': not a valid index", name),
-            ExecError::BadSubstitution(s) => format!("`{}': bad substitution", s),
-            ExecError::BadFd(fd) => format!("{}: bad file descriptor", fd),
-            ExecError::CannotOverwriteExistingFile(file) => format!("{}: cannot overwrite existing file", file),
-            ExecError::InvalidName(name) => format!("`{}': invalid name", name),
-            ExecError::InvalidOption(opt) => format!("{}: invalid option", opt),
+            ExecError::AmbiguousRedirect(name) => format!("{name}: ambiguous redirect"),
+            ExecError::ArrayIndexInvalid(name) => format!("`{name}': not a valid index"),
+            ExecError::BadSubstitution(s) => format!("`{s}': bad substitution"),
+            ExecError::BadFd(fd) => format!("{fd}: bad file descriptor"),
+            ExecError::CannotOverwriteExistingFile(file) => {
+                format!("{file}: cannot overwrite existing file")
+            }
+            ExecError::InvalidName(name) => format!("`{name}': invalid name"),
+            ExecError::InvalidOption(opt) => format!("{opt}: invalid option"),
             ExecError::Interrupted => "interrupted".to_string(),
-            ExecError::ValidOnlyInFunction(com) => format!("{}: can only be used in a function", &com),
-            ExecError::VariableReadOnly(name) => format!("{}: readonly variable", name),
-            ExecError::VariableInvalid(name) => format!("`{}': not a valid identifier", name),
+            ExecError::ValidOnlyInFunction(com) => {
+                format!("{}: can only be used in a function", &com)
+            }
+            ExecError::VariableReadOnly(name) => format!("{name}: readonly variable"),
+            ExecError::VariableInvalid(name) => format!("`{name}': not a valid identifier"),
             ExecError::ParseIntError(e) => e.to_string(),
             ExecError::SyntaxError(near) => format!("syntax error near {}", &near),
-            ExecError::Restricted(com) => format!("{}: restricted", com), 
-            ExecError::SubstringMinus(n) => format!("{}: substring expression < 0", n),
-            ExecError::UnsupportedWaitStatus(ws) => format!("Unsupported wait status: {:?}", ws),
-            ExecError::UnboundVariable(name) => format!("{}: unbound variable", name),
-            ExecError::Errno(e) => format!("system error {:?}", e),
-            ExecError::Bug(msg) => format!("INTERNAL BUG: {}", msg),
+            ExecError::Restricted(com) => format!("{com}: restricted"),
+            ExecError::SubstringMinus(n) => format!("{n}: substring expression < 0"),
+            ExecError::UnsupportedWaitStatus(ws) => format!("Unsupported wait status: {ws:?}"),
+            ExecError::UnboundVariable(name) => format!("{name}: unbound variable"),
+            ExecError::Errno(e) => format!("system error {e:?}"),
+            ExecError::Bug(msg) => format!("INTERNAL BUG: {msg}"),
             ExecError::Other(name) => name.to_string(),
 
-            ExecError::ArithError(s, a) =>  format!("{}: {}", s, String::from(a)),
+            ExecError::ArithError(s, a) => format!("{}: {}", s, String::from(a)),
             ExecError::ParseError(p) => From::from(p),
         }
     }
@@ -104,7 +108,7 @@ impl ExecError {
         let s: String = From::<&ExecError>::from(self);
         if core.db.flags.contains('i') {
             eprintln!("{}: {}", &name, &s);
-        }else{
+        } else {
             let lineno = core.db.get_param("LINENO").unwrap_or("".to_string());
             eprintln!("{}: line {}: {}", &name, &lineno, s);
         }

--- a/src/error/input.rs
+++ b/src/error/input.rs
@@ -13,7 +13,7 @@ impl From<&InputError> for String {
     fn from(e: &InputError) -> String {
         match e {
             InputError::NotUtf8 => "input error: illegal utf-8 character".to_string(),
-            InputError::NoSuchFile(filename) => format!("{}: No such file or directory", filename),
+            InputError::NoSuchFile(filename) => format!("{filename}: No such file or directory"),
             InputError::Eof => "syntax error: unexpected end of file".to_string(),
             InputError::Interrupt => "interrupted".to_string(),
         }

--- a/src/error/parse.rs
+++ b/src/error/parse.rs
@@ -1,8 +1,8 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
 use super::input::InputError;
+use crate::ShellCore;
 
 #[derive(Debug, Clone)]
 pub enum ParseError {
@@ -15,9 +15,9 @@ pub enum ParseError {
 impl From<&ParseError> for String {
     fn from(e: &ParseError) -> String {
         match e {
-            ParseError::UnexpectedSymbol(s) => format!("Unexpected token: {}", s),
+            ParseError::UnexpectedSymbol(s) => format!("Unexpected token: {s}"),
             ParseError::Input(e) => From::from(e),
-            ParseError::WrongAlias(msg) => format!("Someting wrong alias: {}", msg),
+            ParseError::WrongAlias(msg) => format!("Someting wrong alias: {msg}"),
         }
     }
 }
@@ -28,7 +28,7 @@ impl ParseError {
         let s: String = From::<&ParseError>::from(self);
         if core.db.flags.contains('i') {
             eprintln!("{}: {}", &name, &s);
-        }else{
+        } else {
             let lineno = core.db.get_param("LINENO").unwrap_or("".to_string());
             eprintln!("{}: line {}: {}", &name, &lineno, s);
         }

--- a/src/feeder.rs
+++ b/src/feeder.rs
@@ -1,14 +1,14 @@
 //SPDX-FileCopyrightText: 2022 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-mod terminal;
 mod scanner;
+mod terminal;
 
-use std::fs::File;
-use std::io::{BufRead, BufReader, Lines};
-use crate::{ShellCore, utils};
 use crate::error::input::InputError;
 use crate::error::parse::ParseError;
+use crate::{utils, ShellCore};
+use std::fs::File;
+use std::io::{BufRead, BufReader, Lines};
 use std::sync::atomic::Ordering::Relaxed;
 
 #[derive(Debug, Default)]
@@ -46,7 +46,7 @@ impl Feeder {
 
     pub fn set_file(&mut self, s: &str) -> Result<(), InputError> {
         let file = match File::open(s) {
-            Ok(f)  => f,
+            Ok(f) => f,
             Err(_) => return Err(InputError::NoSuchFile(s.to_string())),
         };
         self.script_lines = Some(BufReader::new(file).lines());
@@ -68,7 +68,7 @@ impl Feeder {
             self.lineno_addition -= 1;
             self.lineno -= 1;
         }
-        
+
         ans
     }
 
@@ -81,7 +81,9 @@ impl Feeder {
     }
 
     pub fn pop_backup(&mut self) {
-        self.backup.pop().expect("SUSHI INTERNAL ERROR (backup error)");
+        self.backup
+            .pop()
+            .expect("SUSHI INTERNAL ERROR (backup error)");
     }
 
     pub fn add_backup(&mut self, line: &str) {
@@ -90,13 +92,16 @@ impl Feeder {
                 b.pop();
                 b.pop();
             }
-            *b += &line;
+            *b += line;
         }
     }
 
     pub fn rewind(&mut self) {
-        self.remaining = self.backup.pop().expect("SUSHI INTERNAL ERROR (backup error)");
-    }   
+        self.remaining = self
+            .backup
+            .pop()
+            .expect("SUSHI INTERNAL ERROR (backup error)");
+    }
 
     fn read_script(&mut self) -> Result<String, InputError> {
         if self.c_mode {
@@ -105,7 +110,6 @@ impl Feeder {
             }
 
             return Ok(self.c_mode_buffer.remove(0) + "\n");
-
         }
 
         if let Some(lines) = self.script_lines.as_mut() {
@@ -119,8 +123,8 @@ impl Feeder {
     }
 
     fn feed_additional_line_core(&mut self, core: &mut ShellCore) -> Result<(), InputError> {
-        if ! self.main_feeder {
-             return Err(InputError::Eof);
+        if !self.main_feeder {
+            return Err(InputError::Eof);
         }
 
         if core.sigint.load(Relaxed) {
@@ -128,7 +132,7 @@ impl Feeder {
         }
 
         let line = match core.db.flags.contains('i') && self.script_lines.is_none() {
-            true  => terminal::read_line(core, "PS2"),
+            true => terminal::read_line(core, "PS2"),
             false => self.read_script(),
         };
 
@@ -144,17 +148,17 @@ impl Feeder {
             Err(InputError::Interrupt) => {
                 core.db.exit_status = 130;
                 Err(ParseError::Input(InputError::Interrupt))
-            },
+            }
             Err(e) => {
                 core.db.exit_status = 2;
-                return Err(ParseError::Input(e));
-            },
+                Err(ParseError::Input(e))
+            }
         }
     }
 
     pub fn feed_line(&mut self, core: &mut ShellCore) -> Result<(), InputError> {
         let line = match core.db.flags.contains('i') && self.script_lines.is_none() {
-            true  => terminal::read_line(core, "PS1"),
+            true => terminal::read_line(core, "PS1"),
             false => self.read_script(),
         };
 
@@ -180,14 +184,20 @@ impl Feeder {
     }
 
     pub fn starts_withs(&self, vs: &[&str]) -> bool {
-        vs.iter().any(|s| self.remaining.starts_with(s) )
+        vs.iter().any(|s| self.remaining.starts_with(s))
     }
 
-    pub fn starts_withs2(&self, vs: &Vec<String>) -> bool {
-        vs.iter().any(|s| self.remaining.starts_with(s) )
+    pub fn starts_withs2(&self, vs: &[String]) -> bool {
+        vs.iter().any(|s| self.remaining.starts_with(s))
     }
 
-    pub fn starts_with(&self, s: &str) -> bool { self.remaining.starts_with(s) }
-    pub fn len(&self) -> usize { self.remaining.len() }
-    pub fn is_empty(&self) -> bool { self.remaining.is_empty() }
+    pub fn starts_with(&self, s: &str) -> bool {
+        self.remaining.starts_with(s)
+    }
+    pub fn len(&self) -> usize {
+        self.remaining.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.remaining.is_empty()
+    }
 }

--- a/src/feeder/scanner.rs
+++ b/src/feeder/scanner.rs
@@ -23,23 +23,27 @@ impl Feeder {
     pub fn scanner_char(&mut self) -> usize {
         match self.remaining.chars().next() {
             Some(c) => c.len_utf8(),
-            None    => 0,
+            None => 0,
         }
     }
 
-    fn scanner_chars(&mut self, judge: fn(char) -> bool,
-                     core: &mut ShellCore, skip_bytes: usize) -> usize {
+    fn scanner_chars(
+        &mut self,
+        judge: fn(char) -> bool,
+        core: &mut ShellCore,
+        skip_bytes: usize,
+    ) -> usize {
         loop {
             let mut ans = 0;
             for ch in self.remaining[skip_bytes..].chars() {
                 match judge(ch) {
-                    true  => ans += ch.len_utf8(),
+                    true => ans += ch.len_utf8(),
                     false => break,
                 }
             }
 
-            match &self.remaining[skip_bytes+ans..] == "\\\n" {
-                true  => self.feed_and_connect(core),
+            match &self.remaining[skip_bytes + ans..] == "\\\n" {
+                true => self.feed_and_connect(core),
                 false => return ans,
             }
         }
@@ -55,8 +59,10 @@ impl Feeder {
     }
 
     pub fn scanner_subword_symbol(&self) -> usize {
-        self.scanner_one_of(&["{", "}", ",", "$", "~", "/", "*", "?", "%", "!",
-                              "@", "!", "+", "-", ".", ":", "=", "^", ",", "]"])
+        self.scanner_one_of(&[
+            "{", "}", ",", "$", "~", "/", "*", "?", "%", "!", "@", "!", "+", "-", ".", ":", "=",
+            "^", ",", "]",
+        ])
     }
 
     pub fn scanner_math_symbol(&mut self, core: &mut ShellCore) -> usize {
@@ -75,7 +81,7 @@ impl Feeder {
 
     pub fn scanner_math_output_format(&mut self, core: &mut ShellCore) -> usize {
         self.backslash_check_and_feed(vec!["[#", "["], core);
-        if ! self.starts_with("[#") {
+        if !self.starts_with("[#") {
             return 0;
         }
 
@@ -86,7 +92,7 @@ impl Feeder {
                 ans += 1;
                 continue;
             }
-            if '0' <= ch && ch <= '9' {
+            if ch.is_ascii_digit() {
                 ok = true;
                 ans += 1;
                 continue;
@@ -110,96 +116,108 @@ impl Feeder {
             self.feed_and_connect(core);
         }
 
-        if ! self.starts_with("\\") {
+        if !self.starts_with("\\") {
             return 0;
         }
 
         match self.remaining.chars().nth(1) {
             Some(ch) => 1 + ch.len_utf8(),
-            None =>     1,
+            None => 1,
         }
     }
 
     pub fn scanner_ansi_c_oct(&mut self, core: &mut ShellCore) -> usize {
-        if ! self.starts_with("\\") {
+        if !self.starts_with("\\") {
             return 0;
         }
 
-        let judge = |ch| '0' <= ch && ch <= '7';
+        let judge = |ch| ('0'..='7').contains(&ch);
         self.scanner_chars(judge, core, 1) + 1
     }
 
     pub fn scanner_ansi_c_hex(&mut self, core: &mut ShellCore) -> usize {
-        if ! self.starts_with("\\x") {
+        if !self.starts_with("\\x") {
             return 0;
         }
 
         let mut skip = 2;
         if self.starts_with("\\x{") {
             skip = 3;
-            let judge = |ch| ch != '}' && ch != '\''; 
+            let judge = |ch| ch != '}' && ch != '\'';
             let len = self.scanner_chars(judge, core, skip) + skip;
             return len + self.scanner_chars(|c| c == '}', core, len);
         }
 
-        let judge = |ch| ('0' <= ch && ch <= '9') 
-                         || ('a' <= ch && ch <= 'f') 
-                         || ('A' <= ch && ch <= 'F'); 
+        let judge = |ch: char| {
+            ch.is_ascii_digit() || ('a'..='f').contains(&ch) || ('A'..='F').contains(&ch)
+        };
         self.scanner_chars(judge, core, skip) + skip
     }
 
     pub fn scanner_ansi_unicode4(&mut self, core: &mut ShellCore) -> usize {
-        if ! self.starts_with("\\u") {
+        if !self.starts_with("\\u") {
             return 0;
         }
 
-        let judge = |ch| ('0' <= ch && ch <= '9') 
-                         || ('a' <= ch && ch <= 'f') 
-                         || ('A' <= ch && ch <= 'F'); 
+        let judge = |ch: char| {
+            ch.is_ascii_digit() || ('a'..='f').contains(&ch) || ('A'..='F').contains(&ch)
+        };
         self.scanner_chars(judge, core, 2) + 2
     }
 
     pub fn scanner_ansi_unicode8(&mut self, core: &mut ShellCore) -> usize {
-        if ! self.starts_with("\\U") {
+        if !self.starts_with("\\U") {
             return 0;
         }
 
-        let judge = |ch| ('0' <= ch && ch <= '9') 
-                         || ('a' <= ch && ch <= 'f') 
-                         || ('A' <= ch && ch <= 'F'); 
+        let judge = |ch: char| {
+            ch.is_ascii_digit() || ('a'..='f').contains(&ch) || ('A'..='F').contains(&ch)
+        };
         self.scanner_chars(judge, core, 2) + 2
     }
 
     pub fn scanner_history_expansion(&mut self, _: &mut ShellCore) -> usize {
         match self.starts_with("!$") {
-            true  => 2,
+            true => 2,
             false => 0,
         }
     }
 
     pub fn scanner_dollar_special_and_positional_param(&mut self, core: &mut ShellCore) -> usize {
-        if ! self.starts_with("$") {
+        if !self.starts_with("$") {
             return 0;
         }
         self.backslash_check_and_feed(vec!["$"], core);
 
         match self.remaining.chars().nth(1) {
-            Some(c) => if "$?*@#-!0123456789".find(c) != None { 2 }else{ 0 },
-            None    => 0,
+            Some(c) => {
+                if "$?*@#-!0123456789".find(c).is_some() {
+                    2
+                } else {
+                    0
+                }
+            }
+            None => 0,
         }
     }
 
     pub fn scanner_special_and_positional_param(&mut self) -> usize {
         match self.remaining.chars().nth(0) {
-            Some(c) => if "$?*@#-!_0123456789".find(c) != None { 1 }else{ 0 },
-            None    => 0,
+            Some(c) => {
+                if "$?*@#-!_0123456789".find(c).is_some() {
+                    1
+                } else {
+                    0
+                }
+            }
+            None => 0,
         }
     }
 
     pub fn scanner_subword(&mut self) -> usize {
         let mut ans = 0;
         for ch in self.remaining.chars() {
-            if " \t\n;&|()<>{},\\'$/~\"*+-?@!.:=^]`%".find(ch) != None {
+            if " \t\n;&|()<>{},\\'$/~\"*+-?@!.:=^]`%".find(ch).is_some() {
                 break;
             }
             ans += ch.len_utf8();
@@ -208,88 +226,105 @@ impl Feeder {
     }
 
     pub fn scanner_double_quoted_subword(&mut self, core: &mut ShellCore) -> usize {
-        let judge = |ch| "`\"\\$".find(ch) == None;
+        let judge = |ch| "`\"\\$".find(ch).is_none();
         self.scanner_chars(judge, core, 0)
     }
 
     pub fn scanner_extglob_subword(&mut self, core: &mut ShellCore) -> usize {
-        let judge = |ch| ")|,}".find(ch) == None;
+        let judge = |ch| ")|,}".find(ch).is_none();
         self.scanner_chars(judge, core, 0)
     }
 
     pub fn scanner_single_quoted_subword(&mut self, core: &mut ShellCore) -> usize {
-        if ! self.starts_with("'") {
+        if !self.starts_with("'") {
             return 0;
         }
 
         loop {
             if let Some(n) = self.remaining[1..].find("'") {
                 return n + 2;
-            }else if ! self.feed_additional_line(core).is_ok() {
+            } else if self.feed_additional_line(core).is_err() {
                 return 0;
             }
         }
     }
 
     pub fn scanner_inner_subscript(&mut self, core: &mut ShellCore) -> usize {
-        let judge = |ch| "]".find(ch) == None;
+        let judge = |ch| "]".find(ch).is_none();
         self.scanner_chars(judge, core, 0)
     }
 
     pub fn scanner_unknown_in_param_brace(&mut self) -> usize {
         match self.remaining.chars().nth(0) {
-            Some(c) => if "'$".find(c) == None { c.len_utf8() }else{ 0 },
-            None    => 0,
+            Some(c) => {
+                if "'$".find(c).is_none() {
+                    c.len_utf8()
+                } else {
+                    0
+                }
+            }
+            None => 0,
         }
     }
 
     pub fn scanner_blank(&mut self, core: &mut ShellCore) -> usize {
-        let judge = |ch| " \t".find(ch) != None;
+        let judge = |ch| " \t".find(ch).is_some();
         self.scanner_chars(judge, core, 0)
     }
 
     pub fn scanner_multiline_blank(&mut self, core: &mut ShellCore) -> usize {
-        let judge = |ch| " \t\n".find(ch) != None;
+        let judge = |ch| " \t\n".find(ch).is_some();
         self.scanner_chars(judge, core, 0)
     }
 
     pub fn scanner_binary_operator(&mut self, core: &mut ShellCore) -> usize {
-        self.backslash_check_and_feed(vec!["<<", ">>", "+", "-", "/", "*", "%", "<",
-                                           ">", "=", "&", "|", "^", "/", "%"], core);
-        self.scanner_one_of(&["<<=", ">>=",
-            "&&", "||", "**", "==", "!=", "*=", "/=", "%=", "+=", "-=", "&=", "^=", "|=",
-            ">>", "<<", "<=", ">=", "&", "^", "=", "+", "-", "/", "*", "%", "<", ">", "|", "^", ","])
+        self.backslash_check_and_feed(
+            vec![
+                "<<", ">>", "+", "-", "/", "*", "%", "<", ">", "=", "&", "|", "^", "/", "%",
+            ],
+            core,
+        );
+        self.scanner_one_of(&[
+            "<<=", ">>=", "&&", "||", "**", "==", "!=", "*=", "/=", "%=", "+=", "-=", "&=", "^=",
+            "|=", ">>", "<<", "<=", ">=", "&", "^", "=", "+", "-", "/", "*", "%", "<", ">", "|",
+            "^", ",",
+        ])
     }
 
     pub fn scanner_substitution(&mut self, core: &mut ShellCore) -> usize {
-        self.backslash_check_and_feed(vec!["*", "/", "%", "+", "-", "<",
-                                           "<<", ">", ">>", "^", "|"], core);
-        self.scanner_one_of(&["=", "*=", "/=", "%=", "+=", "-=", "<<=", ">>=", "&=", "^=", "|="])
-
+        self.backslash_check_and_feed(
+            vec!["*", "/", "%", "+", "-", "<", "<<", ">", ">>", "^", "|"],
+            core,
+        );
+        self.scanner_one_of(&[
+            "=", "*=", "/=", "%=", "+=", "-=", "<<=", ">>=", "&=", "^=", "|=",
+        ])
     }
 
     pub fn scanner_uint(&mut self, core: &mut ShellCore) -> usize {
-        let judge = |ch| '0' <= ch && ch <= '9';
+        let judge = |ch: char| ch.is_ascii_digit();
         self.scanner_chars(judge, core, 0)
     }
 
     pub fn scanner_arith_number(&mut self, core: &mut ShellCore) -> usize {
-        let judge = |ch| ('0' <= ch && ch <= '9') 
-                         || ('a' <= ch && ch <= 'z') 
-                         || ('A' <= ch && ch <= 'Z') 
-                         || ".#xX_@".contains(ch);
+        let judge = |ch: char| {
+            ch.is_ascii_digit()
+                || ch.is_ascii_lowercase()
+                || ch.is_ascii_uppercase()
+                || ".#xX_@".contains(ch)
+        };
         self.scanner_chars(judge, core, 0)
     }
 
     pub fn scanner_name(&mut self, core: &mut ShellCore) -> usize {
         let c = self.remaining.chars().nth(0).unwrap_or('0');
-        if '0' <= c && c <= '9' {
+        if c.is_ascii_digit() {
             return 0;
         }
 
-        let judge = |ch| ch == '_' || ('0' <= ch && ch <= '9')
-                         || ('a' <= ch && ch <= 'z')
-                         || ('A' <= ch && ch <= 'Z');
+        let judge = |ch: char| {
+            ch == '_' || ch.is_ascii_digit() || ch.is_ascii_lowercase() || ch.is_ascii_uppercase()
+        };
         self.scanner_chars(judge, core, 0)
     }
 
@@ -303,7 +338,7 @@ impl Feeder {
             name_len + 1
         } else if self.remaining[name_len..].starts_with("+=") {
             name_len + 2
-        }else{
+        } else {
             0
         }
     }
@@ -322,17 +357,17 @@ impl Feeder {
         if self.starts_with("||") {
             return 0;
         }
-        self.scanner_one_of(&["|&","|"])
+        self.scanner_one_of(&["|&", "|"])
     }
 
     pub fn scanner_comment(&self) -> usize {
-        if ! self.remaining.starts_with("#") {
+        if !self.remaining.starts_with("#") {
             return 0;
         }
 
         let mut ans = 0;
         for ch in self.remaining.chars() {
-            if "\n".find(ch) != None {
+            if "\n".find(ch).is_some() {
                 break;
             }
             ans += ch.len_utf8();
@@ -359,29 +394,31 @@ impl Feeder {
 
     pub fn scanner_test_check_option(&mut self, core: &mut ShellCore) -> usize {
         match self.remaining.chars().nth(0) {
-            Some('-') => {},
+            Some('-') => {}
             _ => return 0,
         }
         self.backslash_check_and_feed(vec!["-"], core);
 
         if let Some(c) = self.remaining.chars().nth(1) {
             match "abcdefghknoprstuvwxzGLNOS".contains(c) {
-                true  => return 2,
+                true => return 2,
                 false => return 0,
             }
         }
-        return 0;
+        0
     }
 
     pub fn scanner_test_compare_op(&mut self, core: &mut ShellCore) -> usize {
         self.backslash_check_and_feed(vec!["-", "-e", "-n", "-o", "=", "!"], core);
-        self.scanner_one_of(&["-ef", "-nt", "-ot", "==", "=~", "=", "!=", "<", ">",
-                              "-eq", "-ne", "-lt", "-le", "-gt", "-ge"])
+        self.scanner_one_of(&[
+            "-ef", "-nt", "-ot", "==", "=~", "=", "!=", "<", ">", "-eq", "-ne", "-lt", "-le",
+            "-gt", "-ge",
+        ])
     }
 
     pub fn scanner_regex_symbol(&mut self) -> usize {
         match self.starts_with(" ") {
-            true  => 0,
+            true => 0,
             false => 1,
         }
     }

--- a/src/feeder/terminal.rs
+++ b/src/feeder/terminal.rs
@@ -4,21 +4,21 @@
 mod completion;
 mod key;
 
-use crate::{file_check, ShellCore};
-use crate::utils::file;
 use crate::error::input::InputError;
-use std::io;
-use std::fs::File;
-use std::io::{Write, Stdout};
-use std::sync::atomic::Ordering::Relaxed;
-use std::path::Path;
+use crate::utils::file;
+use crate::{file_check, ShellCore};
 use nix::unistd;
 use nix::unistd::User;
-use termion::event;
+use std::fs::File;
+use std::io;
+use std::io::{Stdout, Write};
+use std::path::Path;
+use std::sync::atomic::Ordering::Relaxed;
 use termion::cursor::DetectCursorPos;
+use termion::event;
 use termion::event::Key;
-use termion::raw::{IntoRawMode, RawTerminal};
 use termion::input::TermRead;
+use termion::raw::{IntoRawMode, RawTerminal};
 use unicode_width::UnicodeWidthChar;
 
 struct Terminal {
@@ -40,17 +40,17 @@ struct Terminal {
 }
 
 fn oct_string(s: &str) -> bool {
-    if s.chars().nth(0) != Some('\\') {
+    if !s.starts_with('\\') {
         return false;
     }
 
     for i in 1..4 {
         match s.chars().nth(i) {
             Some(c) => {
-                if c < '0' || '9' < c {
+                if !c.is_ascii_digit() {
                     return false;
                 }
-            },
+            }
             _ => return false,
         }
     }
@@ -73,10 +73,10 @@ fn oct_to_hex_in_str(from: &str) -> String {
     let mut ans = String::new();
     for p in pos {
         ans += &from[prev..p];
-        if let Ok(n) = u32::from_str_radix(&from[p+1..p+4], 8) {
+        if let Ok(n) = u32::from_str_radix(&from[p + 1..p + 4], 8) {
             ans += &char::from_u32(n).unwrap().to_string();
         }
-        prev = p+4;
+        prev = p + 4;
     }
     ans += &from[prev..];
     ans
@@ -84,16 +84,19 @@ fn oct_to_hex_in_str(from: &str) -> String {
 
 impl Terminal {
     pub fn new(core: &mut ShellCore, ps: &str) -> Self {
-        let raw_prompt = core.db.get_param(ps).unwrap_or(String::new());
+        let raw_prompt = core.db.get_param(ps).unwrap_or_default();
         let ansi_on_prompt = oct_to_hex_in_str(&raw_prompt);
 
         let replaced_prompt = Self::make_prompt_string(&ansi_on_prompt);
-        let prompt = replaced_prompt.replace("\\[", "").replace("\\]", "").to_string();
-        print!("{}", prompt);
+        let prompt = replaced_prompt
+            .replace("\\[", "")
+            .replace("\\]", "")
+            .to_string();
+        print!("{prompt}");
         io::stdout().flush().unwrap();
 
         let mut sout = io::stdout().into_raw_mode().unwrap();
-        let row = sout.cursor_pos().unwrap_or((1,1)).1;
+        let row = sout.cursor_pos().unwrap_or((1, 1)).1;
 
         Terminal {
             prompt: prompt.to_string(),
@@ -113,19 +116,19 @@ impl Terminal {
         }
     }
 
-    fn get_branch(cwd: &String) -> String {
+    fn get_branch(cwd: &str) -> String {
         let mut dirs: Vec<String> = cwd.split("/").map(|s| s.to_string()).collect();
-        while dirs.len() > 0 {
+        while !dirs.is_empty() {
             let path = dirs.join("/") + "/.git/HEAD";
             dirs.pop();
 
-            if ! file_check::is_regular_file(&path) {
+            if !file_check::is_regular_file(&path) {
                 continue;
             }
 
-            if let Ok(mut f) = File::open(Path::new(&path)){
+            if let Ok(mut f) = File::open(Path::new(&path)) {
                 return match f.read_line() {
-                    Ok(Some(s)) => s.replace("ref: refs/heads/","") + "🌵",
+                    Ok(Some(s)) => s.replace("ref: refs/heads/", "") + "🌵",
                     _ => "".to_string(),
                 };
             }
@@ -160,14 +163,17 @@ impl Terminal {
         }
 
         raw.replace("\\u", &user)
-           .replace("\\h", &hostname)
-           .replace("\\w", &cwd)
-           .replace("\\b", &branch)
-           .to_string()
+            .replace("\\h", &hostname)
+            .replace("\\w", &cwd)
+            .replace("\\b", &branch)
+            .to_string()
     }
 
     fn make_width_map(prompt: &str) -> Vec<usize> {
-        let tmp = prompt.replace("\\[", "\x01").replace("\\]", "\x02").to_string();
+        let tmp = prompt
+            .replace("\\[", "\x01")
+            .replace("\\]", "\x02")
+            .to_string();
         let mut in_escape = false;
         let mut ans = vec![];
         for c in tmp.chars() {
@@ -177,7 +183,7 @@ impl Terminal {
             }
 
             let wid = match in_escape {
-                true  => 0,
+                true => 0,
                 false => UnicodeWidthChar::width(c).unwrap_or(0),
             };
             ans.push(wid);
@@ -186,7 +192,7 @@ impl Terminal {
     }
 
     fn write(&mut self, s: &str) {
-        write!(self.stdout, "{}", s).unwrap();
+        write!(self.stdout, "{s}").unwrap();
     }
 
     fn flush(&mut self) {
@@ -207,9 +213,13 @@ impl Terminal {
     }
 
     fn shift_in_range(x: &mut usize, shift: i32, min: usize, max: usize) {
-        *x = if      shift < 0 && *x < min + (- shift as usize) { min }
-             else if shift > 0 && *x + (shift as usize) > max   { max }
-             else           { (*x as isize + shift as isize) as usize };
+        *x = if shift < 0 && *x < min + (-shift as usize) {
+            min
+        } else if shift > 0 && *x + (shift as usize) > max {
+            max
+        } else {
+            (*x as isize + shift as isize) as usize
+        };
     }
 
     fn head_to_cursor_pos(&self, head: usize, y_origin: usize) -> (usize, usize) {
@@ -227,7 +237,7 @@ impl Terminal {
             if x + w > col {
                 y += 1;
                 x = w;
-            }else{
+            } else {
                 x += w;
             }
         }
@@ -247,7 +257,7 @@ impl Terminal {
     fn rewrite(&mut self, erase: bool) {
         self.goto(0);
         if erase {
-            self.write(&termion::clear::AfterCursor.to_string());
+            self.write(termion::clear::AfterCursor.as_ref());
         }
         self.write(&self.get_string(0).replace("\n", "\n\r"));
         self.goto(self.head);
@@ -295,9 +305,12 @@ impl Terminal {
 
     pub fn shift_cursor(&mut self, shift: i32) {
         let prev = self.head;
-        Self::shift_in_range(&mut self.head, shift, 
-                             self.prompt.chars().count(),
-                             self.chars.len());
+        Self::shift_in_range(
+            &mut self.head,
+            shift,
+            self.prompt.chars().count(),
+            self.chars.len(),
+        );
 
         if prev == self.head {
             self.cloop();
@@ -318,7 +331,7 @@ impl Terminal {
         }
     }
 
-    pub fn check_terminal_size(&mut self/*, prev_size: &mut (usize, usize)*/) {
+    pub fn check_terminal_size(&mut self /*, prev_size: &mut (usize, usize)*/) {
         //if *prev_size == Terminal::size() {
         if self.size == Terminal::size() {
             return;
@@ -332,20 +345,29 @@ impl Terminal {
         self.prompt_row = std::cmp::max(cur_row, 1) as usize;
     }
 
-    pub fn call_history(&mut self, inc: i32, core: &mut ShellCore){
+    pub fn call_history(&mut self, inc: i32, core: &mut ShellCore) {
         let prev = self.hist_ptr;
         let prev_str = self.get_string(self.prompt.chars().count());
-        Self::shift_in_range(&mut self.hist_ptr, inc, 0, std::isize::MAX as usize);
+        Self::shift_in_range(&mut self.hist_ptr, inc, 0, isize::MAX as usize);
 
         self.chars = self.prompt.chars().collect();
-        self.chars.extend(core.fetch_history(self.hist_ptr, prev, prev_str).replace("↵ \0", "\n").chars());
+        self.chars.extend(
+            core.fetch_history(self.hist_ptr, prev, prev_str)
+                .replace("↵ \0", "\n")
+                .chars(),
+        );
         self.head = self.chars.len();
         self.rewrite(true);
     }
 
     pub fn set_double_tab_completion(&mut self, core: &ShellCore) {
-        let tail = match core.completion.current.o_options.contains(&"nospace".to_string()) {
-            true  => "",
+        let tail = match core
+            .completion
+            .current
+            .o_options
+            .contains(&"nospace".to_string())
+        {
+            true => "",
             false => " ",
         };
 
@@ -360,27 +382,28 @@ impl Terminal {
 
     fn completion_finish_check(&mut self) {
         match self.prev_key {
-            event::Key::Char('\t') 
-                | event::Key::Left | event::Key::Down
-                | event::Key::Right | event::Key::Up => return,
+            event::Key::Char('\t')
+            | event::Key::Left
+            | event::Key::Down
+            | event::Key::Right
+            | event::Key::Up => (),
             _ => {
                 self.tab_num = 0;
                 self.completion_candidate = String::new();
-            },
+            }
         }
     }
 }
 
 fn signal_check(core: &mut ShellCore, term: &mut Terminal) -> Result<bool, InputError> {
-    if core.sigint.load(Relaxed) 
-    || core.trapped.iter_mut().any(|t| t.0.load(Relaxed)) {
+    if core.sigint.load(Relaxed) || core.trapped.iter_mut().any(|t| t.0.load(Relaxed)) {
         term.write("\r\n");
         return Err(InputError::Interrupt);
     }
     Ok(true)
 }
 
-pub fn read_line(core: &mut ShellCore, prompt: &str) -> Result<String, InputError>{
+pub fn read_line(core: &mut ShellCore, prompt: &str) -> Result<String, InputError> {
     let mut term = Terminal::new(core, prompt);
     signal_check(core, &mut term)?;
 
@@ -400,8 +423,8 @@ pub fn read_line(core: &mut ShellCore, prompt: &str) -> Result<String, InputErro
             Ok(false) => term.prev_key = c,
             Err(e) => {
                 core.history.remove(0);
-                return Err(e)
-            },
+                return Err(e);
+            }
         }
 
         term.completion_finish_check();
@@ -416,7 +439,7 @@ pub fn read_line(core: &mut ShellCore, prompt: &str) -> Result<String, InputErro
 /*TODO: The following version uses async_stdin and enables
  * the shell be interrupted by signals. However, some bugs
  * found around cursor control. Moreover, this implementation
- * causes a SIGTTIN signal after a command runs. 
+ * causes a SIGTTIN signal after a command runs.
  */
 /*
 pub fn read_line(core: &mut ShellCore, prompt: &str) -> Result<String, InputError>{

--- a/src/feeder/terminal/completion.rs
+++ b/src/feeder/terminal/completion.rs
@@ -1,21 +1,21 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{file_check, Feeder, ShellCore, utils};
 use crate::core::builtins::compgen;
 use crate::core::completion::CompletionEntry;
-use crate::error::exec::ExecError;
 use crate::elements::command::simple::SimpleCommand;
 use crate::elements::command::Command;
 use crate::elements::io::pipe::Pipe;
+use crate::error::exec::ExecError;
 use crate::feeder::terminal::Terminal;
+use crate::{file_check, utils, Feeder, ShellCore};
 use unicode_width::UnicodeWidthStr;
 
 fn str_width(s: &str) -> usize {
     UnicodeWidthStr::width(s)
 }
 
-fn common_length(chars: &Vec<char>, s: &String) -> usize {
+fn common_length(chars: &[char], s: &str) -> usize {
     let max_len = chars.len();
     for (i, c) in s.chars().enumerate() {
         if i >= max_len || chars[i] != c {
@@ -25,7 +25,7 @@ fn common_length(chars: &Vec<char>, s: &String) -> usize {
     max_len
 }
 
-fn common_string(paths: &Vec<String>) -> String {
+fn common_string(paths: &[String]) -> String {
     if paths.is_empty() {
         return "".to_string();
     }
@@ -34,7 +34,7 @@ fn common_string(paths: &Vec<String>) -> String {
     let mut common_len = ref_chars.len();
 
     for path in &paths[1..] {
-        let len = common_length(&ref_chars, &path);
+        let len = common_length(&ref_chars, path);
         common_len = std::cmp::min(common_len, len);
     }
 
@@ -43,20 +43,23 @@ fn common_string(paths: &Vec<String>) -> String {
 
 fn is_dir(s: &str, core: &mut ShellCore) -> bool {
     let tilde_prefix = "~/".to_string();
-    let tilde_path = core.db.get_param("HOME").unwrap_or(String::new()) + "/";
+    let tilde_path = core.db.get_param("HOME").unwrap_or_default() + "/";
 
     file_check::is_dir(&s.replace(&tilde_prefix, &tilde_path))
 }
 
-fn apply_o_options(cand: &mut String, core: &mut ShellCore, o_options: &Vec<String>) {
+fn apply_o_options(cand: &mut String, core: &mut ShellCore, o_options: &[String]) {
     let mut tail = " ";
     if is_dir(cand, core) {
         tail = "/";
     }
 
     if file_check::exists(cand) {
-        *cand = cand.replace(" ", "\\ ").replace("(", "\\(").replace(")", "\\)");
-        if ! is_dir(cand, core) {
+        *cand = cand
+            .replace(" ", "\\ ")
+            .replace("(", "\\(")
+            .replace(")", "\\)");
+        if !is_dir(cand, core) {
             tail = tail.trim_end();
         }
     }
@@ -74,34 +77,39 @@ impl Terminal {
         let _ = core.db.set_array("COMPREPLY", Some(vec![]), None);
         self.set_completion_info(core)?;
 
-        if ! self.set_custom_compreply(core).is_ok()
-        && ! self.set_default_compreply(core).is_ok() {
+        if self.set_custom_compreply(core).is_err() && self.set_default_compreply(core).is_err() {
             self.cloop();
             return Ok(());
         }
 
         let mut cands = core.db.get_vec("COMPREPLY", true)?;
-        cands.retain(|c| c != "");
+        cands.retain(|c| !c.is_empty());
         let o_options = core.completion.current.o_options.clone();
         for cand in cands.iter_mut() {
             apply_o_options(cand, core, &o_options);
         }
 
-        match self.tab_num  {
-            1 => self.try_completion(&mut cands, core).unwrap(),
-            _ => self.show_list(&mut cands),
+        match self.tab_num {
+            1 => self.try_completion(&cands, core).unwrap(),
+            _ => self.show_list(&cands),
         }
         Ok(())
     }
 
-    fn exec_complete_function(org_word: &str, prev_pos: i32, cur_pos: i32, 
-                              core: &mut ShellCore)-> Result<(), ExecError> {
+    fn exec_complete_function(
+        org_word: &str,
+        prev_pos: i32,
+        cur_pos: i32,
+        core: &mut ShellCore,
+    ) -> Result<(), ExecError> {
         let prev_word = core.db.get_elem("COMP_WORDS", &prev_pos.to_string())?;
         let target_word = core.db.get_elem("COMP_WORDS", &cur_pos.to_string())?;
         let info = &core.completion.current;
 
-        let command = format!("{} \"{}\" \"{}\" \"{}\"",
-                                &info.function, &org_word, &target_word, &prev_word);
+        let command = format!(
+            "{} \"{}\" \"{}\" \"{}\"",
+            &info.function, &org_word, &target_word, &prev_word
+        );
         let mut feeder = Feeder::new(&command);
 
         if let Ok(Some(mut a)) = SimpleCommand::parse(&mut feeder, core) {
@@ -111,11 +119,14 @@ impl Terminal {
         Ok(())
     }
 
-    fn exec_action(cur_pos: i32, core: &mut ShellCore)-> Result<(), ExecError> {
+    fn exec_action(cur_pos: i32, core: &mut ShellCore) -> Result<(), ExecError> {
         let target_word = core.db.get_elem("COMP_WORDS", &cur_pos.to_string())?;
         let info = &core.completion.current;
 
-        let command = format!("COMPREPLY=($(compgen -A \"{}\" \"{}\"))",  &info.action, &target_word);
+        let command = format!(
+            "COMPREPLY=($(compgen -A \"{}\" \"{}\"))",
+            &info.action, &target_word
+        );
         let mut feeder = Feeder::new(&command);
 
         if let Ok(Some(mut a)) = SimpleCommand::parse(&mut feeder, core) {
@@ -138,17 +149,16 @@ impl Terminal {
 
         let info = match core.completion.entries.get(&org_word) {
             Some(i) => i.clone(),
-            None    => {
-                let mut tmp = CompletionEntry::default();
-                tmp.function = core.completion.default_function.clone();
-                tmp
+            None => CompletionEntry {
+                function: core.completion.default_function.clone(),
+                ..Default::default()
             },
         };
 
         core.completion.current = info.clone();
-        if info.function != "" {
+        if !info.function.is_empty() {
             Self::exec_complete_function(&org_word, prev_pos, cur_pos, core)?;
-        }else if info.action != "" {
+        } else if !info.action.is_empty() {
             Self::exec_action(cur_pos, core)?;
         }
 
@@ -159,7 +169,11 @@ impl Terminal {
     }
 
     fn get_cur_pos(core: &mut ShellCore) -> i32 {
-        core.db.get_param("COMP_CWORD").unwrap().parse::<i32>().unwrap()
+        core.db
+            .get_param("COMP_CWORD")
+            .unwrap()
+            .parse::<i32>()
+            .unwrap()
     }
 
     pub fn set_default_compreply(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
@@ -168,26 +182,39 @@ impl Terminal {
 
         let com = core.db.get_elem("COMP_WORDS", "0")?;
 
-        let (tilde_prefix, tilde_path, last_tilde_expanded) = Self::set_tilde_transform(&last, core);
+        let (tilde_prefix, tilde_path, last_tilde_expanded) =
+            Self::set_tilde_transform(&last, core);
 
-        let mut args = vec!["".to_string(), "".to_string(), last_tilde_expanded.to_string()];
+        let mut args = vec![
+            "".to_string(),
+            "".to_string(),
+            last_tilde_expanded.to_string(),
+        ];
 
         let list = self.make_default_compreply(core, &mut args, &com, &pos);
         if list.is_empty() {
             return Err(ExecError::Other("empty list".to_string()));
         }
 
-        let tmp: Vec<String> = list.iter().map(|p| p.replacen(&tilde_path, &tilde_prefix, 1)).collect();
+        let tmp: Vec<String> = list
+            .iter()
+            .map(|p| p.replacen(&tilde_path, &tilde_prefix, 1))
+            .collect();
         core.db.set_array("COMPREPLY", Some(tmp), None)
     }
 
-    fn make_default_compreply(&mut self, core: &mut ShellCore, args: &mut Vec<String>,
-                              com: &str, pos: &str) -> Vec<String> {
+    fn make_default_compreply(
+        &mut self,
+        core: &mut ShellCore,
+        args: &mut Vec<String>,
+        com: &str,
+        pos: &str,
+    ) -> Vec<String> {
         if core.completion.entries.contains_key(com) {
             let action = core.completion.entries[com].action.clone();
             let options = core.completion.entries[com].options.clone();
 
-            if action != "" {
+            if !action.is_empty() {
                 let mut cands = match action.as_ref() {
                     "alias" => compgen::compgen_a(core, args),
                     "command" => compgen::compgen_c(core, args),
@@ -198,14 +225,17 @@ impl Terminal {
                     "variable" => compgen::compgen_v(core, args),
                     _ => vec![],
                 };
-    
+
                 if options.contains_key("-P") {
                     let prefix = &options["-P"];
                     cands = cands.iter().map(|c| prefix.clone() + c).collect();
                 }
                 if options.contains_key("-S") {
                     let suffix = &options["-S"];
-                    cands = cands.iter().map(|c| c.to_owned() + &suffix.clone()).collect();
+                    cands = cands
+                        .iter()
+                        .map(|c| c.to_owned() + &suffix.clone())
+                        .collect();
                 }
                 return cands;
             }
@@ -214,8 +244,12 @@ impl Terminal {
         if pos == "0" {
             return if core.db.len("COMP_WORDS") == 0 {
                 self.escape_at_completion = false;
-                compgen::compgen_h(core, args).to_vec().into_iter().filter(|h| h.len() > 0).collect()
-            }else{
+                compgen::compgen_h(core, args)
+                    .to_vec()
+                    .into_iter()
+                    .filter(|h| !h.is_empty())
+                    .collect()
+            } else {
                 compgen::compgen_c(core, args)
             };
         }
@@ -223,12 +257,12 @@ impl Terminal {
         compgen::compgen_f(core, args, false)
     }
 
-    pub fn try_completion(&mut self, cands: &mut Vec<String>, core: &mut ShellCore) -> Result<(), String> {
+    pub fn try_completion(&mut self, cands: &[String], core: &mut ShellCore) -> Result<(), String> {
         let pos = core.db.get_param("COMP_CWORD")?;
         let target = core.db.get_elem("COMP_WORDS", &pos)?;
 
-        let common = common_string(&cands);
-        if common.len() != target.len() && ! common.is_empty() {
+        let common = common_string(cands);
+        if common.len() != target.len() && !common.is_empty() {
             self.replace_input(&common);
             return Ok(());
         }
@@ -237,12 +271,12 @@ impl Terminal {
     }
 
     fn normalize_tab(&mut self, row_num: i32, col_num: i32) {
-        let i = (self.tab_col*row_num + self.tab_row + row_num*col_num)%(row_num*col_num);
-        self.tab_col = i/row_num;
-        self.tab_row = i%row_num;
+        let i = (self.tab_col * row_num + self.tab_row + row_num * col_num) % (row_num * col_num);
+        self.tab_col = i / row_num;
+        self.tab_row = i % row_num;
     }
 
-    fn show_list(&mut self, list: &Vec<String>) {
+    fn show_list(&mut self, list: &[String]) {
         if list.is_empty() {
             return;
         }
@@ -250,14 +284,11 @@ impl Terminal {
         let widths: Vec<usize> = list.iter().map(|s| str_width(s)).collect();
         let max_entry_width = widths.iter().max().unwrap_or(&1000) + 1;
         let terminal_row_num = self.size.1;
-        let col_num = std::cmp::min(
-                          std::cmp::max(self.size.0 / max_entry_width, 1),
-                          list.len()
-                      );
+        let col_num = std::cmp::min(std::cmp::max(self.size.0 / max_entry_width, 1), list.len());
         let row_num = std::cmp::min(
-                          (list.len()-1) / col_num + 1,
-                          std::cmp::max(terminal_row_num - 2, 1)
-                      );
+            (list.len() - 1) / col_num + 1,
+            std::cmp::max(terminal_row_num - 2, 1),
+        );
         self.completion_candidate = String::new();
 
         if self.tab_num > 2 {
@@ -268,8 +299,7 @@ impl Terminal {
         for row in 0..row_num {
             for col in 0..col_num {
                 let tab = self.tab_row == row as i32 && self.tab_col == col as i32;
-                self.print_an_entry(list, &widths, row, col, 
-                    row_num, max_entry_width, tab);
+                self.print_an_entry(list, &widths, row, col, row_num, max_entry_width, tab);
             }
             print!("\r\n");
         }
@@ -277,26 +307,34 @@ impl Terminal {
         let (cur_col, cur_row) = self.head_to_cursor_pos(self.head, self.prompt_row);
 
         self.check_scroll();
-        match cur_row as usize == terminal_row_num {
+        match cur_row == terminal_row_num {
             true => {
                 let back_row = std::cmp::max(cur_row as i16 - row_num as i16, 1);
                 self.write(&termion::cursor::Goto(cur_col as u16, back_row as u16).to_string());
                 print!("\x1b[1A");
                 self.flush();
-            },
+            }
             false => self.rewrite(false),
         }
     }
 
-    fn print_an_entry(&mut self, list: &Vec<String>, widths: &Vec<usize>,
-        row: usize, col: usize, row_num: usize, width: usize, pointed: bool) {
-        let i = col*row_num + row;
+    fn print_an_entry(
+        &mut self,
+        list: &[String],
+        widths: &[usize],
+        row: usize,
+        col: usize,
+        row_num: usize,
+        width: usize,
+        pointed: bool,
+    ) {
+        let i = col * row_num + row;
         let space_num = match i < list.len() {
-            true  => width - widths[i],
+            true => width - widths[i],
             false => width,
         };
         let cand = match i < list.len() {
-            true  => list[i].clone(),
+            true => list[i].clone(),
             false => "".to_string(),
         };
 
@@ -304,25 +342,26 @@ impl Terminal {
         if pointed {
             print!("\x1b[01;7m{}{}\x1b[00m", &cand, &s);
             self.completion_candidate = cand;
-        }else{
+        } else {
             print!("{}{}", &cand, &s);
         }
     }
 
     fn shave_existing_word(&mut self) {
-        while self.head > self.prompt.chars().count() 
-        && ( self.head > 0 && self.chars[self.head-1] != ' ' ||
-           (self.head > 1 && self.chars[self.head-1] == ' ' 
-            && self.chars[self.head-2] == '\\') ) {
+        while self.head > self.prompt.chars().count()
+            && (self.head > 0 && self.chars[self.head - 1] != ' '
+                || (self.head > 1
+                    && self.chars[self.head - 1] == ' '
+                    && self.chars[self.head - 2] == '\\'))
+        {
             self.backspace();
         }
-        while self.head < self.chars.len() 
-        && self.chars[self.head] != ' ' {
+        while self.head < self.chars.len() && self.chars[self.head] != ' ' {
             self.delete();
         }
     }
 
-    pub fn replace_input(&mut self, to: &String) {
+    pub fn replace_input(&mut self, to: &str) {
         self.shave_existing_word();
         let to_modified = to.replace("↵ \0", "\n");
         for c in to_modified.chars() {
@@ -339,9 +378,9 @@ impl Terminal {
 
         if last.starts_with("~/") {
             tilde_prefix = "~/".to_string();
-            tilde_path = core.db.get_param("HOME").unwrap_or(String::new()) + "/";
+            tilde_path = core.db.get_param("HOME").unwrap_or_default() + "/";
             last_tilde_expanded = last.replacen(&tilde_prefix, &tilde_path, 1);
-        }else{
+        } else {
             tilde_prefix = String::new();
             tilde_path = String::new();
             last_tilde_expanded = last.to_string();
@@ -352,7 +391,8 @@ impl Terminal {
 
     fn set_completion_info(&mut self, core: &mut ShellCore) -> Result<(), ExecError> {
         let prompt_len = self.prompt.chars().count();
-        core.db.set_param("COMP_POINT", &(self.head - prompt_len).to_string(), None)?;
+        core.db
+            .set_param("COMP_POINT", &(self.head - prompt_len).to_string(), None)?;
 
         let all_string = self.get_string(prompt_len);
         core.db.set_param("COMP_LINE", &all_string, None)?;
@@ -361,7 +401,7 @@ impl Terminal {
             1 => "\t",
             _ => "?",
         };
-        core.db.set_param("COMP_TYPE", &tp, None)?;
+        core.db.set_param("COMP_TYPE", tp, None)?;
         core.db.set_param("COMP_KEY", "9", None)?;
 
         let mut words_all = utils::split_words(&all_string);
@@ -376,13 +416,11 @@ impl Terminal {
 
         let mut num = words_left.len();
         match left_string.chars().last() {
-            Some(' ') => {num -= 1},
+            Some(' ') => num -= 1,
             Some(_) => {
-                if num > 0 {
-                    num -= 1
-                }
-            },
-            _ => {},
+                num = num.saturating_sub(1);
+            }
+            _ => {}
         }
 
         let _ = core.db.set_param("COMP_CWORD", &num.to_string(), None);
@@ -390,7 +428,7 @@ impl Terminal {
     }
 }
 
-fn completion_from(ws: &Vec<String>, core: &mut ShellCore) -> usize {
+fn completion_from(ws: &[String], core: &mut ShellCore) -> usize {
     for i in 0..ws.len() {
         if utils::reserved(&ws[i]) {
             continue;

--- a/src/feeder/terminal/key.rs
+++ b/src/feeder/terminal/key.rs
@@ -1,29 +1,28 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
-use crate::error::input::InputError;
-use std::sync::atomic::Ordering::Relaxed;
 use super::Terminal;
+use crate::error::input::InputError;
+use crate::ShellCore;
+use std::sync::atomic::Ordering::Relaxed;
 use termion::event;
 use termion::event::Key;
 
 pub fn action(core: &mut ShellCore, term: &mut Terminal, c: &Key) -> Result<bool, InputError> {
     match c {
         event::Key::Ctrl(ch) => ctrl(core, term, *ch)?,
-        event::Key::Down |
-        event::Key::Left |
-        event::Key::Right |
-        event::Key::Up => arrow(term, core, c),
+        event::Key::Down | event::Key::Left | event::Key::Right | event::Key::Up => {
+            arrow(term, core, c)
+        }
         event::Key::Backspace => term.backspace(),
         event::Key::Delete => term.delete(),
         event::Key::Char(c) => return char_key(term, core, c),
-        _  => {},
+        _ => {}
     }
     Ok(false)
 }
 
-fn ctrl(core: &mut ShellCore, term: &mut Terminal, c: char) -> Result<(), InputError>{
+fn ctrl(core: &mut ShellCore, term: &mut Terminal, c: char) -> Result<(), InputError> {
     match c {
         'a' => term.goto_origin(),
         'b' => term.shift_cursor(-1),
@@ -32,18 +31,18 @@ fn ctrl(core: &mut ShellCore, term: &mut Terminal, c: char) -> Result<(), InputE
             term.goto(term.chars.len());
             term.write("^C\r\n");
             return Err(InputError::Interrupt);
-        },
+        }
         'd' => {
             if term.chars.len() == term.prompt.chars().count() {
                 term.write("\r\n");
                 return Err(InputError::Eof);
-            }else{
+            } else {
                 term.delete();
             }
-        },
+        }
         'e' => term.goto_end(),
         'f' => term.shift_cursor(1),
-        _ => {},
+        _ => {}
     }
     Ok(())
 }
@@ -51,37 +50,36 @@ fn ctrl(core: &mut ShellCore, term: &mut Terminal, c: char) -> Result<(), InputE
 fn arrow(term: &mut Terminal, core: &mut ShellCore, key: &event::Key) {
     if term.tab_num > 1 {
         match key {
-            event::Key::Down  => term.tab_row += 1,
-            event::Key::Up    => term.tab_row -= 1,
+            event::Key::Down => term.tab_row += 1,
+            event::Key::Up => term.tab_row -= 1,
             event::Key::Right => term.tab_col += 1,
-            event::Key::Left  => term.tab_col -= 1,
-            _ => {},
+            event::Key::Left => term.tab_col -= 1,
+            _ => {}
         }
         let _ = term.completion(core);
-    }else{
+    } else {
         match key {
-            event::Key::Down  => term.call_history(-1, core),
-            event::Key::Up    => term.call_history(1, core),
+            event::Key::Down => term.call_history(-1, core),
+            event::Key::Up => term.call_history(1, core),
             event::Key::Right => term.shift_cursor(1),
-            event::Key::Left  => term.shift_cursor(-1),
-            _ => {},
+            event::Key::Left => term.shift_cursor(-1),
+            _ => {}
         }
     }
 }
 
-fn char_key(term: &mut Terminal, core: &mut ShellCore, c: &char)
-                                       -> Result<bool, InputError> {
+fn char_key(term: &mut Terminal, core: &mut ShellCore, c: &char) -> Result<bool, InputError> {
     match c {
         '\n' => {
-            if term.completion_candidate.len() > 0 {
+            if !term.completion_candidate.is_empty() {
                 term.set_double_tab_completion(core);
-            }else{
+            } else {
                 term.goto(term.chars.len());
                 term.write("\r\n");
                 term.chars.push('\n');
                 return Ok(true);
             }
-        },
+        }
         '\t' => {
             if term.tab_num == 0 || term.prev_key == event::Key::Char('\t') {
                 term.tab_num += 1;
@@ -89,11 +87,11 @@ fn char_key(term: &mut Terminal, core: &mut ShellCore, c: &char)
             if term.tab_num == 2 {
                 term.tab_row = -1;
                 term.tab_col = 0;
-            }else if term.tab_num > 2 {
+            } else if term.tab_num > 2 {
                 term.tab_row += 1;
             }
             let _ = term.completion(core);
-        },
+        }
         c => term.insert(*c),
     }
     Ok(false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,71 +2,72 @@
 //SPDX-License-Identifier: BSD-3-Clause
 
 mod core;
+mod elements;
 mod error;
 mod feeder;
-mod elements;
 mod main_c_option;
-mod signal;
 mod proc_ctrl;
+mod signal;
 mod utils;
 
-use builtins::option;
-use std::{env, process};
-use std::sync::atomic::Ordering::Relaxed;
+use crate::core::builtins::source;
 use crate::core::{builtins, ShellCore};
 use crate::elements::script::Script;
 use crate::feeder::Feeder;
-use utils::{exit, file_check, arg};
+use builtins::option;
 use error::input::InputError;
-use crate::core::builtins::source;
+use std::sync::atomic::Ordering::Relaxed;
+use std::{env, process};
+use utils::{arg, exit, file_check};
 
 fn show_version() {
-    const V: &'static str = env!("CARGO_PKG_VERSION");
-    const P: &'static str = env!("CARGO_BUILD_PROFILE");
-    eprintln!("Rusty Bash (a.k.a. Sushi shell), version {} - {}
+    const V: &str = env!("CARGO_PKG_VERSION");
+    const P: &str = env!("CARGO_BUILD_PROFILE");
+    eprintln!(
+        "Rusty Bash (a.k.a. Sushi shell), version {V} - {P}
 © 2024 Ryuichi Ueda
 License: BSD 3-Clause
 
 This is open source software. You can redistirbute and use in source
 and binary forms with or without modification under the license.
-There is no warranty, to the extent permitted by law.", V, P);
+There is no warranty, to the extent permitted by law."
+    );
     process::exit(0);
 }
 
 fn read_rc_file(core: &mut ShellCore) {
-    if ! core.db.flags.contains("i") {
+    if !core.db.flags.contains("i") {
         return;
     }
 
-    let mut dir = core.db.get_param("CARGO_MANIFEST_DIR").unwrap_or(String::new());
-    if dir == "" {
-        dir = core.db.get_param("HOME").unwrap_or(String::new());
+    let mut dir = core.db.get_param("CARGO_MANIFEST_DIR").unwrap_or_default();
+    if dir.is_empty() {
+        dir = core.db.get_param("HOME").unwrap_or_default();
     }
 
     let rc_file = dir + "/.sushrc";
 
     if file_check::is_regular_file(&rc_file) {
-        core.db.exit_status = source::source(core, &mut vec![".".to_string(), rc_file]);
+        core.db.exit_status = source::source(core, &[".".to_string(), rc_file]);
     }
 }
 
 fn consume_file_and_subsequents(args: &mut Vec<String>) -> Vec<String> {
-    let len = args.len();
     let mut skip = false;
     let mut pos = None;
 
-    for i in 1..len {
+    for (i, arg) in args.iter().enumerate().skip(1) {
         if skip {
             skip = false;
             continue;
         }
 
-        if args[i].starts_with("-o") || args[i].starts_with("+o") {
+        if arg.starts_with("-o") || arg.starts_with("+o") {
             skip = true;
             continue;
         }
 
-        if args[i].starts_with("-") || args[i].starts_with("+") {
+        if arg.starts_with("-") || arg.starts_with("+") {
             continue;
         }
 
@@ -119,14 +120,14 @@ fn set_short_options(args: &mut Vec<String>, core: &mut ShellCore) {
 
 fn set_parameters(script_parts: Vec<String>, core: &mut ShellCore, command: &str) {
     match script_parts.is_empty() {
-        true  => {
+        true => {
             core.db.position_parameters[0] = vec![command.to_string()];
             core.script_name = "-".to_string();
-        },
+        }
         false => {
             core.db.position_parameters[0] = script_parts;
             core.script_name = core.db.position_parameters[0][0].clone();
-        },
+        }
     }
 }
 
@@ -152,9 +153,9 @@ fn main() {
     set_o_options(&mut args, &mut core);
     set_short_options(&mut args, &mut core);
 
-    if ! c_opt {
+    if !c_opt {
         set_parameters(script_parts, &mut core, &command);
-    }else{
+    } else {
         main_c_option::set_parameters(&script_parts, &mut core, &args[0]);
         main_c_option::run_and_exit(&args, &script_parts, &mut core); //exit here
     }
@@ -174,26 +175,29 @@ fn set_history(core: &mut ShellCore, s: &str) {
     }
 
     core.history[0] = s.trim_end().replace("\n", "↵ \0").to_string();
-    if core.history[0].is_empty()
-    || (core.history.len() > 1 && core.history[0] == core.history[1]) {
+    if core.history[0].is_empty() || (core.history.len() > 1 && core.history[0] == core.history[1])
+    {
         core.history.remove(0);
     }
 }
 
 fn show_message() {
-    const V: &'static str = env!("CARGO_PKG_VERSION");
-    const P: &'static str = env!("CARGO_BUILD_PROFILE");
-    eprintln!("Rusty Bash (a.k.a. Sushi shell), version {} - {}", V, P);
+    const V: &str = env!("CARGO_PKG_VERSION");
+    const P: &str = env!("CARGO_BUILD_PROFILE");
+    eprintln!("Rusty Bash (a.k.a. Sushi shell), version {V} - {P}");
 }
 
-fn main_loop(core: &mut ShellCore, command: &String) {
+fn main_loop(core: &mut ShellCore, command: &str) {
     let mut feeder = Feeder::new("");
     feeder.main_feeder = true;
 
     if core.script_name != "-" {
         core.db.flags.retain(|f| f != 'i');
-        if let Err(_) = feeder.set_file(&core.script_name) {
-            eprintln!("{}: {}: No such file or directory", command, &core.script_name); 
+        if feeder.set_file(&core.script_name).is_err() {
+            eprintln!(
+                "{}: {}: No such file or directory",
+                command, &core.script_name
+            );
             process::exit(2);
         }
     }
@@ -204,7 +208,7 @@ fn main_loop(core: &mut ShellCore, command: &String) {
 
     loop {
         match feed_script(&mut feeder, core) {
-            (true, false) => {},
+            (true, false) => {}
             (false, true) => break,
             _ => parse_and_exec(&mut feeder, core, true),
         }
@@ -217,9 +221,9 @@ fn main_loop(core: &mut ShellCore, command: &String) {
     exit::normal(core);
 }
 
-
 fn feed_script(feeder: &mut Feeder, core: &mut ShellCore) -> (bool, bool) {
-    if let Err(e) = core.jobtable_check_status() {          //(continue, break)
+    if let Err(e) = core.jobtable_check_status() {
+        //(continue, break)
         e.print(core);
     }
 
@@ -233,14 +237,14 @@ fn feed_script(feeder: &mut Feeder, core: &mut ShellCore) -> (bool, bool) {
             signal::input_interrupt_check(feeder, core);
             signal::check_trap(core);
             (true, false)
-        },
+        }
         _ => (false, true),
     }
 }
 
 fn parse_and_exec(feeder: &mut Feeder, core: &mut ShellCore, set_hist: bool) {
     core.sigint.store(false, Relaxed);
-    match Script::parse(feeder, core, false){
+    match Script::parse(feeder, core, false) {
         Ok(Some(mut s)) => {
             if let Err(e) = s.exec(core) {
                 e.print(core);
@@ -248,16 +252,16 @@ fn parse_and_exec(feeder: &mut Feeder, core: &mut ShellCore, set_hist: bool) {
             if set_hist {
                 set_history(core, &s.get_text());
             }
-        },
+        }
         Err(e) => {
             e.print(core);
             feeder.consume(feeder.len());
             feeder.nest = vec![("".to_string(), vec![])];
-        },
+        }
         _ => {
             feeder.consume(feeder.len());
             feeder.nest = vec![("".to_string(), vec![])];
-        },
+        }
     }
     core.sigint.store(false, Relaxed);
 }

--- a/src/main_c_option.rs
+++ b/src/main_c_option.rs
@@ -1,19 +1,19 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
+use crate::core::{builtins, ShellCore};
+use crate::feed_script;
+use crate::feeder::Feeder;
+use crate::parse_and_exec;
+use crate::signal;
+use crate::utils::exit;
 use builtins::option;
 use std::process;
-use crate::core::{builtins, ShellCore};
-use crate::feeder::Feeder;
-use crate::utils::exit;
-use crate::signal;
-use crate::parse_and_exec;
-use crate::feed_script;
 
-pub fn set_parameters(c_parts: &Vec<String>, core: &mut ShellCore, command: &str) {
+pub fn set_parameters(c_parts: &[String], core: &mut ShellCore, command: &str) {
     let parameters = if c_parts.len() > 1 {
         c_parts[1..].to_vec()
-    }else{
+    } else {
         vec![command.to_string()]
     };
 
@@ -24,12 +24,12 @@ pub fn set_parameters(c_parts: &Vec<String>, core: &mut ShellCore, command: &str
     }
 }
 
-pub fn run_and_exit(args: &Vec<String>, c_parts: &Vec<String>, core: &mut ShellCore) {
+pub fn run_and_exit(args: &[String], c_parts: &[String], core: &mut ShellCore) {
     core.configure_c_mode();
 
-    if c_parts.len() < 1 {
+    if c_parts.is_empty() {
         println!("{}: -c: option requires an argument", &args[0]);
-        process::exit(2);                
+        process::exit(2);
     }
 
     signal::run_signal_check(core);
@@ -45,7 +45,7 @@ pub fn run_and_exit(args: &Vec<String>, c_parts: &Vec<String>, core: &mut ShellC
 
     loop {
         match feed_script(&mut feeder, core) {
-            (true, false) => {},
+            (true, false) => {}
             (false, true) => break,
             _ => parse_and_exec(&mut feeder, core, false),
         }

--- a/src/proc_ctrl.rs
+++ b/src/proc_ctrl.rs
@@ -1,23 +1,27 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::{exit, error, Feeder, Script, ShellCore, signal};
 use crate::error::exec::ExecError;
-use nix::unistd;
+use crate::{error, exit, signal, Feeder, Script, ShellCore};
 use nix::errno::Errno;
-use nix::sys::{resource, wait};
 use nix::sys::resource::UsageWho;
 use nix::sys::signal::Signal;
 use nix::sys::wait::{WaitPidFlag, WaitStatus};
+use nix::sys::{resource, wait};
 use nix::time::{clock_gettime, ClockId};
+use nix::unistd;
 use nix::unistd::Pid;
-use std::process;
 use std::ffi::CString;
+use std::process;
 use std::sync::atomic::Ordering::Relaxed;
 
-pub fn wait_pipeline(core: &mut ShellCore, pids: Vec<Option<Pid>>,
-                     exclamation: bool, time: bool) -> Vec<WaitStatus> {
-    if pids.len() == 1 && pids[0] == None {
+pub fn wait_pipeline(
+    core: &mut ShellCore,
+    pids: Vec<Option<Pid>>,
+    exclamation: bool,
+    time: bool,
+) -> Vec<WaitStatus> {
+    if pids.len() == 1 && pids[0].is_none() {
         if time {
             show_time(core);
         }
@@ -32,11 +36,12 @@ pub fn wait_pipeline(core: &mut ShellCore, pids: Vec<Option<Pid>>,
     let mut pipestatus = vec![];
     let mut ans = vec![];
     for pid in &pids {
-        if pid.is_some() { //None: lastpipe
+        if pid.is_some() {
+            //None: lastpipe
             let ws = wait_process(core, pid.unwrap());
             ans.push(ws);
             pipestatus.push(core.db.exit_status);
-        }else{
+        } else {
             pipestatus.push(last_exit_status);
             core.db.exit_status = last_exit_status;
         }
@@ -46,13 +51,17 @@ pub fn wait_pipeline(core: &mut ShellCore, pids: Vec<Option<Pid>>,
         show_time(core);
     }
     set_foreground(core);
-    let _ = core.db.set_array("PIPESTATUS", Some(pipestatus.iter().map(|e|e.to_string()).collect()), None);
+    let _ = core.db.set_array(
+        "PIPESTATUS",
+        Some(pipestatus.iter().map(|e| e.to_string()).collect()),
+        None,
+    );
 
     if core.options.query("pipefail") {
         pipestatus.retain(|e| *e != 0);
 
-        if pipestatus.len() != 0 {
-            core.db.exit_status = pipestatus[pipestatus.len()-1];
+        if !pipestatus.is_empty() {
+            core.db.exit_status = pipestatus[pipestatus.len() - 1];
         }
     }
 
@@ -67,8 +76,8 @@ pub fn wait_pipeline(core: &mut ShellCore, pids: Vec<Option<Pid>>,
 
 fn wait_process(core: &mut ShellCore, child: Pid) -> WaitStatus {
     let waitflags = match core.is_subshell {
-        true  => None,
-        false => Some(WaitPidFlag::WUNTRACED | WaitPidFlag::WCONTINUED)
+        true => None,
+        false => Some(WaitPidFlag::WUNTRACED | WaitPidFlag::WCONTINUED),
     };
 
     let ws = wait::waitpid(child, waitflags);
@@ -77,17 +86,17 @@ fn wait_process(core: &mut ShellCore, child: Pid) -> WaitStatus {
         Ok(WaitStatus::Exited(_pid, status)) => status,
         Ok(WaitStatus::Signaled(pid, signal, coredump)) => error::signaled(pid, signal, coredump),
         Ok(WaitStatus::Stopped(pid, signal)) => {
-            eprintln!("Stopped Pid: {:?}, Signal: {:?}", pid, signal);
+            eprintln!("Stopped Pid: {pid:?}, Signal: {signal:?}");
             148
-        },
+        }
         Ok(unsupported) => {
             ExecError::UnsupportedWaitStatus(unsupported).print(core);
             1
-        },
+        }
         Err(err) => {
-            let msg = format!("Error: {:?}", err);
+            let msg = format!("Error: {err:?}");
             exit::internal(&msg);
-        },
+        }
     };
 
     if core.db.exit_status == 130 {
@@ -99,11 +108,11 @@ fn wait_process(core: &mut ShellCore, child: Pid) -> WaitStatus {
 fn set_foreground(core: &ShellCore) {
     let fd = match core.tty_fd.as_ref() {
         Some(fd) => fd,
-        _        => return,
+        _ => return,
     };
 
     let pgid = unistd::getpgid(Some(Pid::from_raw(0)))
-               .expect(&error::internal("cannot get pgid"));
+        .unwrap_or_else(|_| panic!("{}", error::internal("cannot get pgid")));
 
     if unistd::tcgetpgrp(fd) == Ok(pgid) {
         return;
@@ -111,43 +120,55 @@ fn set_foreground(core: &ShellCore) {
 
     signal::ignore(Signal::SIGTTOU); //SIGTTOUを無視
     unistd::tcsetpgrp(fd, pgid)
-        .expect(&error::internal("cannot get the terminal"));
+        .unwrap_or_else(|_| panic!("{}", error::internal("cannot get the terminal")));
     signal::restore(Signal::SIGTTOU); //SIGTTOUを受け付け
 }
 
-pub fn set_pgid(core :&ShellCore, pid: Pid, pgid: Pid) {
+pub fn set_pgid(core: &ShellCore, pid: Pid, pgid: Pid) {
     let _ = unistd::setpgid(pid, pgid);
-    let lastpipe = ! core.db.flags.contains('m') && core.shopts.query("lastpipe");
+    let lastpipe = !core.db.flags.contains('m') && core.shopts.query("lastpipe");
 
-    if ! lastpipe && pid.as_raw() == 0 && pgid.as_raw() == 0 { //以下3行追加
+    if !lastpipe && pid.as_raw() == 0 && pgid.as_raw() == 0 {
+        //以下3行追加
         set_foreground(core);
     }
 }
 
 fn show_time(core: &ShellCore) {
-     let real_end_time = clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap();
+    let real_end_time = clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap();
 
-     let core_usage = resource::getrusage(UsageWho::RUSAGE_SELF).unwrap();
-     let children_usage = resource::getrusage(UsageWho::RUSAGE_CHILDREN).unwrap();
+    let core_usage = resource::getrusage(UsageWho::RUSAGE_SELF).unwrap();
+    let children_usage = resource::getrusage(UsageWho::RUSAGE_CHILDREN).unwrap();
 
-     let real_diff = real_end_time - core.measured_time.real;
-     eprintln!("\nreal\t{}m{}.{:06}s", real_diff.tv_sec()/60,
-               real_diff.tv_sec()%60, real_diff.tv_nsec()/1000);
-     let user_diff = core_usage.user_time() + children_usage.user_time() - core.measured_time.user;
-     eprintln!("user\t{}m{}.{:06}s", user_diff.tv_sec()/60,
-               user_diff.tv_sec()%60, user_diff.tv_usec());
-     let sys_diff = core_usage.system_time() + children_usage.system_time() - core.measured_time.sys;
-     eprintln!("sys \t{}m{}.{:06}s", sys_diff.tv_sec()/60,
-               sys_diff.tv_sec()%60, sys_diff.tv_usec());
+    let real_diff = real_end_time - core.measured_time.real;
+    eprintln!(
+        "\nreal\t{}m{}.{:06}s",
+        real_diff.tv_sec() / 60,
+        real_diff.tv_sec() % 60,
+        real_diff.tv_nsec() / 1000
+    );
+    let user_diff = core_usage.user_time() + children_usage.user_time() - core.measured_time.user;
+    eprintln!(
+        "user\t{}m{}.{:06}s",
+        user_diff.tv_sec() / 60,
+        user_diff.tv_sec() % 60,
+        user_diff.tv_usec()
+    );
+    let sys_diff = core_usage.system_time() + children_usage.system_time() - core.measured_time.sys;
+    eprintln!(
+        "sys \t{}m{}.{:06}s",
+        sys_diff.tv_sec() / 60,
+        sys_diff.tv_sec() % 60,
+        sys_diff.tv_usec()
+    );
 }
 
-pub fn exec_command(args: &Vec<String>, core: &mut ShellCore, fullpath: &String) -> ! {
+pub fn exec_command(args: &[String], core: &mut ShellCore, fullpath: &str) -> ! {
     let cargs = to_cargs(args);
     let cfullpath = CString::new(fullpath.to_string()).unwrap();
 
-    if ! fullpath.is_empty() {
+    if !fullpath.is_empty() {
         let _ = unistd::execv(&cfullpath, &cargs);
-    
     }
     let result = unistd::execvp(&cargs[0], &cargs);
 
@@ -156,27 +177,29 @@ pub fn exec_command(args: &Vec<String>, core: &mut ShellCore, fullpath: &String)
         Err(Errno::EACCES) => exit::permission_denied(&args[0], core),
         Err(Errno::ENOENT) => run_command_not_found(&args[0], core),
         Err(err) => {
-            eprintln!("Failed to execute. {:?}", err);
+            eprintln!("Failed to execute. {err:?}");
             process::exit(127)
         }
-        _ => exit::internal("never come here")
+        _ => exit::internal("never come here"),
     }
 }
 
-fn run_command_not_found(arg: &String, core: &mut ShellCore) -> ! {
+fn run_command_not_found(arg: &str, core: &mut ShellCore) -> ! {
     if core.db.functions.contains_key("command_not_found_handle") {
-        let s = "command_not_found_handle ".to_owned() + &arg.clone();
+        let s = "command_not_found_handle ".to_owned() + arg;
         let mut f = Feeder::new(&s);
         match Script::parse(&mut f, core, false) {
-            Ok(Some(mut script)) => {let _ = script.exec(core);},
+            Ok(Some(mut script)) => {
+                let _ = script.exec(core);
+            }
             Err(e) => e.print(core),
-            _ => {},
+            _ => {}
         }
     }
-    exit::not_found(&arg, core)
+    exit::not_found(arg, core)
 }
 
-fn to_cargs(args: &Vec<String>) -> Vec<CString> {
+fn to_cargs(args: &[String]) -> Vec<CString> {
     args.iter()
         .map(|a| CString::new(a.to_string()).unwrap())
         .collect()

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,40 +1,40 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda ryuichiueda@gmail.com
 //SPDX-License-Identifier: BSD-3-Clause
 
-use nix::sys::signal;
-use nix::sys::signal::{Signal, SigHandler};
-use std::{thread, time};
-use std::sync::Arc;
-use std::sync::atomic::Ordering::Relaxed;
-use crate::Script;
 use crate::core::ShellCore;
 use crate::feeder::Feeder;
+use crate::Script;
+use nix::sys::signal;
+use nix::sys::signal::{SigHandler, Signal};
 use signal_hook::consts;
 use signal_hook::iterator::Signals;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
+use std::{thread, time};
 
 pub fn ignore(sig: Signal) {
-    unsafe { signal::signal(sig, SigHandler::SigIgn) }
-        .expect("sush(fatal): cannot ignore signal");
+    unsafe { signal::signal(sig, SigHandler::SigIgn) }.expect("sush(fatal): cannot ignore signal");
 }
 
 pub fn restore(sig: Signal) {
-    unsafe { signal::signal(sig, SigHandler::SigDfl) }
-        .expect("sush(fatal): cannot restore signal");
+    unsafe { signal::signal(sig, SigHandler::SigDfl) }.expect("sush(fatal): cannot restore signal");
 }
 
 pub fn run_signal_check(core: &mut ShellCore) {
-    for fd in 3..10 { //use FD 3~9 to prevent signal-hool from using these FDs
+    for fd in 3..10 {
+        //use FD 3~9 to prevent signal-hool from using these FDs
         nix::unistd::dup2(2, fd).expect("sush(fatal): init error");
     }
 
     core.sigint.store(true, Relaxed);
     let sigint = Arc::clone(&core.sigint);
- 
-    thread::spawn(move || {
-        let mut signals = Signals::new(vec![consts::SIGINT])
-                          .expect("sush(fatal): cannot prepare signal data");
 
-        for fd in 3..10 { // release FD 3~9
+    thread::spawn(move || {
+        let mut signals =
+            Signals::new(vec![consts::SIGINT]).expect("sush(fatal): cannot prepare signal data");
+
+        for fd in 3..10 {
+            // release FD 3~9
             nix::unistd::close(fd).expect("sush(fatal): init error");
         }
         sigint.store(false, Relaxed);
@@ -53,11 +53,11 @@ pub fn run_signal_check(core: &mut ShellCore) {
     while core.sigint.load(Relaxed) {
         thread::sleep(time::Duration::from_millis(1));
     }
-
 } //thanks: https://dev.to/talzvon/handling-unix-kill-signals-in-rust-55g6
 
 pub fn input_interrupt_check(feeder: &mut Feeder, core: &mut ShellCore) -> bool {
-    if ! core.sigint.load(Relaxed) { //core.input_interrupt {
+    if !core.sigint.load(Relaxed) {
+        //core.input_interrupt {
         return false;
     }
 
@@ -81,9 +81,14 @@ pub fn check_trap(core: &mut ShellCore) {
     for s in scripts {
         let mut feeder = Feeder::new(&s);
         let mut script = match Script::parse(&mut feeder, core, true) {
-            Ok(None) => {continue;},
+            Ok(None) => {
+                continue;
+            }
             Ok(s) => s.unwrap(),
-            Err(e) => {e.print(core); continue;},
+            Err(e) => {
+                e.print(core);
+                continue;
+            }
         };
 
         if let Err(e) = script.exec(core) {

--- a/src/utils/arg.rs
+++ b/src/utils/arg.rs
@@ -14,7 +14,7 @@ pub fn consume_option(opt: &str, args: &mut Vec<String>) -> bool {
 
             args.remove(pos);
             true
-        },
+        }
         None => false,
     }
 }
@@ -22,19 +22,17 @@ pub fn consume_option(opt: &str, args: &mut Vec<String>) -> bool {
 pub fn consume_starts_with(s: &str, args: &mut Vec<String>) -> Vec<String> {
     let mut ans = args.clone();
     ans.retain(|a| a.starts_with(s));
-    args.retain(|a| ! a.starts_with(s));
+    args.retain(|a| !a.starts_with(s));
     ans
 }
 
 pub fn consume_with_next_arg(prev_opt: &str, args: &mut Vec<String>) -> Option<String> {
     match args.iter().position(|a| a == prev_opt) {
-        Some(pos) => {
-            match pos+1 >= args.len() {
-                true  => None,
-                false => {
-                    args.remove(pos);
-                    Some(args.remove(pos))
-                },
+        Some(pos) => match pos + 1 >= args.len() {
+            true => None,
+            false => {
+                args.remove(pos);
+                Some(args.remove(pos))
             }
         },
         None => None,
@@ -47,17 +45,23 @@ pub fn consume_with_subsequents(prev_opt: &str, args: &mut Vec<String>) -> Vec<S
             let ans = args[pos..].to_vec();
             *args = args[..pos].to_vec();
             ans
-        },
+        }
         None => vec![],
     }
 }
 
 pub fn dissolve_option(opt: &str) -> Vec<String> {
-    if opt.starts_with("-") {
-        opt[1..].chars().map(|c| ("-".to_owned() + &c.to_string()).to_string()).collect()
-    }else if opt.starts_with("+") {
-        opt[1..].chars().map(|c| ("+".to_owned() + &c.to_string()).to_string()).collect()
-    }else {
+    if let Some(stripped) = opt.strip_prefix("-") {
+        stripped
+            .chars()
+            .map(|c| ("-".to_owned() + &c.to_string()).to_string())
+            .collect()
+    } else if let Some(stripped) = opt.strip_prefix("+") {
+        stripped
+            .chars()
+            .map(|c| ("+".to_owned() + &c.to_string()).to_string())
+            .collect()
+    } else {
         vec![opt.to_string()]
     }
 }
@@ -82,8 +86,8 @@ pub fn dissolve_options(args: &Vec<String>) -> Vec<String> {
 pub fn dissolve_options_main() -> Vec<String> {
     let mut ans = vec![];
     let mut stop = false;
-    for (i, a) in std::env::args().enumerate() { 
-        if i != 0 && ! a.starts_with("-") || a == "--" {
+    for (i, a) in std::env::args().enumerate() {
+        if i != 0 && !a.starts_with("-") || a == "--" {
             stop = true;
         }
 

--- a/src/utils/clock.rs
+++ b/src/utils/clock.rs
@@ -1,13 +1,16 @@
 //SPDX-FileCopyrightText: 2024 @caro@mi.shellgei.org
 //SPDX-License-Identifier: BSD-3-Clause
 
-use std::time::Duration;
 use nix::time;
 use nix::time::ClockId;
+use std::time::Duration;
 
 pub fn monotonic_time() -> Duration {
     let now = time::clock_gettime(ClockId::CLOCK_MONOTONIC).unwrap();
-    Duration::new(now.tv_sec().try_into().unwrap(), now.tv_nsec().try_into().unwrap())
+    Duration::new(
+        now.tv_sec().try_into().unwrap(),
+        now.tv_nsec().try_into().unwrap(),
+    )
 }
 
 /*

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -1,40 +1,45 @@
 //SPDX-FileCopyrightText: 2025 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
+use super::file_check;
+use super::glob;
 use crate::core::options::Options;
 use std::fs::DirEntry;
 use std::path::Path;
-use super::glob;
-use super::file_check;
 
 pub fn files(dir: &str) -> Vec<String> {
-    let dir = if dir == "" {"."}else{dir};
+    let dir = if dir.is_empty() { "." } else { dir };
 
     let entries = match Path::new(dir).read_dir() {
         Ok(es) => es,
         Err(_) => return vec![],
     };
 
-    let f = |e: DirEntry| e.file_name()
-               .to_string_lossy().to_string();
+    let f = |e: DirEntry| e.file_name().to_string_lossy().to_string();
 
-    entries.map(|e| f(e.unwrap()) ).collect()
+    entries.map(|e| f(e.unwrap())).collect()
 }
 
 fn globstar(dir: &str) -> Vec<String> {
-    let dir = if dir.is_empty() || dir.ends_with("/") { dir } else { &(dir.to_owned() + "/") };
+    let dir = if dir.is_empty() || dir.ends_with("/") {
+        dir
+    } else {
+        &(dir.to_owned() + "/")
+    };
     let mut dirs = vec![dir.to_string()];
-//    let mut ans = dirs.clone();
+    //    let mut ans = dirs.clone();
     let mut ans = vec![];
 
-    while ! dirs.is_empty() {
+    while !dirs.is_empty() {
         let mut tmp = vec![];
         for d in dirs {
-            if file_check::is_symlink(&d.trim_end_matches("/")) {
+            if file_check::is_symlink(d.trim_end_matches("/")) {
                 continue;
             }
             let mut fs = files(&d);
-            fs.iter_mut().for_each(|f| {*f = d.to_string() + &f + "/"; });
+            fs.iter_mut().for_each(|f| {
+                *f = d.to_string() + f + "/";
+            });
             tmp.append(&mut fs);
         }
         ans.extend(tmp.clone());
@@ -52,10 +57,11 @@ pub fn glob(dir: &str, pattern: &str, shopts: &Options) -> Vec<String> {
     let make_path = |f: &str| dir.to_owned() + f + "/";
 
     if ["", ".", ".."].contains(&pattern)
-    || (file_check::is_symlink(dir.trim_end_matches("/")) && shopts.query("globstar")) {
+        || (file_check::is_symlink(dir.trim_end_matches("/")) && shopts.query("globstar"))
+    {
         let path = make_path(pattern);
         match file_check::exists(&path) {
-            true  => return vec![path],
+            true => return vec![path],
             false => return vec![],
         }
     }
@@ -67,16 +73,18 @@ pub fn glob(dir: &str, pattern: &str, shopts: &Options) -> Vec<String> {
     let dotglob = shopts.query("dotglob");
     let extglob = shopts.query("extglob");
     let pat = glob::parse(pattern, extglob);
-    let mut ans: Vec<String> = files(dir).iter()
-        .filter(|f| !f.starts_with(".") || pattern.starts_with(".") || dotglob )
-        .filter(|f| glob::compare(f, &pat) )
-        .map(|f| make_path(&f) ).collect();
+    let mut ans: Vec<String> = files(dir)
+        .iter()
+        .filter(|f| !f.starts_with(".") || pattern.starts_with(".") || dotglob)
+        .filter(|f| glob::compare(f, &pat))
+        .map(|f| make_path(f))
+        .collect();
 
-    if ! shopts.query("globskipdots") {
-        if glob::compare(&"..".to_string(), &pat) {
+    if !shopts.query("globskipdots") {
+        if glob::compare("..", &pat) {
             ans.push(make_path(".."));
         }
-        if glob::compare(&".".to_string(), &pat) {
+        if glob::compare(".", &pat) {
             ans.push(make_path("."));
         }
     }

--- a/src/utils/exit.rs
+++ b/src/utils/exit.rs
@@ -8,7 +8,7 @@ pub fn normal(core: &mut ShellCore) -> ! {
     run_script(core);
 
     core.write_history_to_file();
-    process::exit(core.db.exit_status%256)
+    process::exit(core.db.exit_status % 256)
 }
 
 fn run_script(core: &mut ShellCore) {
@@ -27,15 +27,17 @@ fn run_script(core: &mut ShellCore) {
             if let Err(e) = s.exec(core) {
                 e.print(core);
             }
-        },
-        Err(e) => {e.print(core);},
-        Ok(None) => {},
+        }
+        Err(e) => {
+            e.print(core);
+        }
+        Ok(None) => {}
     };
 }
 
 /* error at exec */
 fn command_error_exit(name: &str, core: &mut ShellCore, msg: &str, exit_status: i32) -> ! {
-    let msg = format!("{}: {}", name, msg);
+    let msg = format!("{name}: {msg}");
     error::print(&msg, core);
     process::exit(exit_status)
 }
@@ -50,17 +52,15 @@ pub fn permission_denied(command_name: &str, core: &mut ShellCore) -> ! {
 
 pub fn not_found(command_name: &str, core: &mut ShellCore) -> ! {
     let msg = "command not found";
-    command_error_exit(command_name, core, &msg, 127)
+    command_error_exit(command_name, core, msg, 127)
 }
 
 pub fn internal(s: &str) -> ! {
-    panic!("SUSH INTERNAL ERROR: {}", s)
+    panic!("SUSH INTERNAL ERROR: {s}")
 }
 
 pub fn check_e_option(core: &mut ShellCore) {
-    if core.db.exit_status != 0 
-    && core.db.flags.contains("e") 
-    && ! core.suspend_e_option {
+    if core.db.exit_status != 0 && core.db.flags.contains("e") && !core.suspend_e_option {
         normal(core);
     }
 }

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -2,25 +2,23 @@
 //SPDX-FileCopyrightText: 2023 @caro@mi.shellgei.org
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::ShellCore;
 use crate::utils::file_check;
+use crate::ShellCore;
 use std::env;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf, Component};
+use std::path::{Component, Path, PathBuf};
 
 pub fn oss_to_name(oss: &OsString) -> String {
     oss.to_string_lossy().to_string()
 }
 
-pub fn buf_to_name(path: &PathBuf) -> String {
+pub fn buf_to_name(path: &Path) -> String {
     path.to_string_lossy().to_string()
 }
 
 pub fn search_command(command: &str) -> Option<String> {
     let paths = env::var_os("PATH");
-    if paths.is_none() {
-        return None;
-    }
+    paths.as_ref()?;
 
     for path in env::split_paths(&paths.unwrap()) {
         let compath = buf_to_name(&path) + "/" + command;
@@ -35,22 +33,24 @@ pub fn search_command(command: &str) -> Option<String> {
 pub fn make_absolute_path(core: &mut ShellCore, path_str: &str) -> PathBuf {
     let path = Path::new(&path_str);
     let mut absolute = PathBuf::new();
-    if ! path.is_relative() {
+    if !path.is_relative() {
         absolute.push(path);
         return absolute;
     }
 
-    if path.starts_with("~") { // tilde -> $HOME
-        let home_dir = core.db.get_param("HOME").unwrap_or(String::new());
-        if home_dir != "" {
+    if path.starts_with("~") {
+        // tilde -> $HOME
+        let home_dir = core.db.get_param("HOME").unwrap_or_default();
+        if !home_dir.is_empty() {
             absolute.push(PathBuf::from(home_dir));
             let num = match path_str.len() > 1 && path_str.starts_with("~/") {
-                true  => 2,
+                true => 2,
                 false => 1,
             };
             absolute.push(PathBuf::from(&path_str[num..]));
         }
-    } else { // current
+    } else {
+        // current
         if let Some(tcwd) = core.get_current_directory() {
             absolute.push(tcwd);
             absolute.push(path);
@@ -66,11 +66,12 @@ pub fn make_canonical_path(core: &mut ShellCore, path_str: &str) -> PathBuf {
     for component in path.components() {
         match component {
             Component::RootDir => canonical.push(Component::RootDir),
-            Component::ParentDir => { canonical.pop(); }, 
+            Component::ParentDir => {
+                canonical.pop();
+            }
             Component::Normal(c) => canonical.push(c),
             _ => (),
         }
     }
     canonical
 }
-

--- a/src/utils/glob.rs
+++ b/src/utils/glob.rs
@@ -20,23 +20,33 @@ pub enum MetaChar {
     CharClass(String),
 }
 
-pub fn parse_and_compare(word: &String, pattern: &str, extglob: bool) -> bool {
+pub fn parse_and_compare(word: &str, pattern: &str, extglob: bool) -> bool {
     let pat = parser::parse(pattern, extglob);
     compare(word, &pat)
 }
 
-pub fn compare(word: &String, pattern: &Vec<GlobElem>) -> bool {
-    comparator::shave_word(word, pattern).iter().any(|c| c == "")
+pub fn compare(word: &str, pattern: &[GlobElem]) -> bool {
+    comparator::shave_word(word, pattern)
+        .iter()
+        .any(|c| c.is_empty())
 }
 
-pub fn longest_match_length(word: &String, pattern: &Vec<GlobElem>) -> usize {
-    word.len() - comparator::shave_word(word, pattern).iter()
-                 .map(|c| c.len()).min().unwrap_or(word.len())
+pub fn longest_match_length(word: &str, pattern: &[GlobElem]) -> usize {
+    word.len()
+        - comparator::shave_word(word, pattern)
+            .iter()
+            .map(|c| c.len())
+            .min()
+            .unwrap_or(word.len())
 }
 
-pub fn shortest_match_length(word: &String, pattern: &Vec<GlobElem>) -> usize {
-    word.len() - comparator::shave_word(word, pattern).iter()
-                 .map(|c| c.len()).max().unwrap_or(word.len())
+pub fn shortest_match_length(word: &str, pattern: &[GlobElem]) -> usize {
+    word.len()
+        - comparator::shave_word(word, pattern)
+            .iter()
+            .map(|c| c.len())
+            .max()
+            .unwrap_or(word.len())
 }
 
 pub fn parse(pattern: &str, extglob: bool) -> Vec<GlobElem> {

--- a/src/utils/glob/comparator.rs
+++ b/src/utils/glob/comparator.rs
@@ -1,36 +1,40 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::exit;
 use super::extglob;
 use super::{GlobElem, MetaChar};
+use crate::exit;
 
-pub fn shave_word(word: &String, pattern: &Vec<GlobElem>) -> Vec<String> {
+pub fn shave_word(word: &str, pattern: &[GlobElem]) -> Vec<String> {
     let mut candidates = vec![word.to_string()];
-    pattern.iter().for_each(|w| shave(&mut candidates, &w) );
+    pattern.iter().for_each(|w| shave(&mut candidates, w));
     candidates
 }
 
 pub fn shave(candidates: &mut Vec<String>, w: &GlobElem) {
     match w {
-        GlobElem::Normal(s) => normal(candidates, &s),
+        GlobElem::Normal(s) => normal(candidates, s),
         GlobElem::Symbol('?') => question(candidates),
         GlobElem::Symbol('*') => asterisk(candidates),
-        GlobElem::OneOf(not, cs) => one_of(candidates, &cs, *not),
-        GlobElem::ExtGlob(prefix, ps) => extglob::shave(candidates, *prefix, &ps),
+        GlobElem::OneOf(not, cs) => one_of(candidates, cs, *not),
+        GlobElem::ExtGlob(prefix, ps) => extglob::shave(candidates, *prefix, ps),
         GlobElem::Symbol(_) => exit::internal("Unknown glob symbol"),
     }
 }
 
 fn normal(cands: &mut Vec<String>, s: &String) {
-    cands.retain(|c| c.starts_with(s) );
-    cands.iter_mut().for_each(|c| {*c = c.split_off(s.len());});
+    cands.retain(|c| c.starts_with(s));
+    cands.iter_mut().for_each(|c| {
+        *c = c.split_off(s.len());
+    });
 }
 
 fn question(cands: &mut Vec<String>) {
-    cands.retain(|c| c.len() != 0 );
-    let len = |c: &String| c.chars().nth(0).unwrap().len_utf8();
-    cands.iter_mut().for_each(|c| {*c = c.split_off(len(c));});
+    cands.retain(|c| !c.is_empty());
+    let len = |c: &String| c.chars().next().unwrap().len_utf8();
+    cands.iter_mut().for_each(|c| {
+        *c = c.split_off(len(c));
+    });
 }
 
 fn asterisk(cands: &mut Vec<String>) {
@@ -49,54 +53,58 @@ fn asterisk(cands: &mut Vec<String>) {
     *cands = ans;
 }
 
-fn one_of(cands: &mut Vec<String>, cs: &Vec<MetaChar>, not_inv: bool) {
+fn one_of(cands: &mut Vec<String>, cs: &[MetaChar], not_inv: bool) {
     if cs.is_empty() {
-        if ! not_inv {
+        if !not_inv {
             cands.clear();
         }
         return;
     }
 
-    cands.retain(|cand| cand.len() != 0 );
-    cands.retain(|cand| cs.iter().any(|c| compare_head(cand, c)) == not_inv );
-    let len = |c: &String| c.chars().nth(0).unwrap().len_utf8();
-    cands.iter_mut().for_each(|c| {*c = c.split_off(len(c));});
+    cands.retain(|cand| !cand.is_empty());
+    cands.retain(|cand| cs.iter().any(|c| compare_head(cand, c)) == not_inv);
+    let len = |c: &String| c.chars().next().unwrap().len_utf8();
+    cands.iter_mut().for_each(|c| {
+        *c = c.split_off(len(c));
+    });
 }
 
-fn compare_head(cand: &String, c: &MetaChar) -> bool {
-    let head = cand.chars().nth(0).unwrap();
+fn compare_head(cand: &str, c: &MetaChar) -> bool {
+    let head = cand.chars().next().unwrap();
     match c {
         MetaChar::Normal(c) => head == *c,
         MetaChar::Range(f, t) => range_check(*f, *t, head),
-        MetaChar::CharClass(cls) => charclass_check(&cls, head),
+        MetaChar::CharClass(cls) => charclass_check(cls, head),
     }
 }
 
 fn range_check(from: char, to: char, c: char) -> bool {
     if ('0' <= from && from <= to && to <= '9')
-    || ('a' <= from && from <= to && to <= 'z')
-    || ('A' <= from && from <= to && to <= 'Z') {
+        || ('a' <= from && from <= to && to <= 'z')
+        || ('A' <= from && from <= to && to <= 'Z')
+    {
         return from <= c && c <= to;
     }
     false
 }
 
 fn charclass_check(cls: &str, c: char) -> bool {
-    match cls { //TODO: rough implementation, no test except for [:space:]
+    match cls {
+        //TODO: rough implementation, no test except for [:space:]
         "[:alnum:]" => c.is_ascii_alphanumeric(),
         "[:alpha:]" => c.is_ascii_alphabetic(),
         "[:ascii:]" => c.is_ascii(),
         "[:blank:]" => c == ' ' || c == '\t',
         "[:cntrl:]" => c.is_ascii_control(),
-        "[:digit:]" => c.is_digit(10),
+        "[:digit:]" => c.is_ascii_digit(),
         "[:graph:]" => c.is_ascii_graphic(),
         "[:lower:]" => c.is_ascii_lowercase(),
-        "[:print:]" => c.is_ascii() && ! c.is_ascii_control(),
+        "[:print:]" => c.is_ascii() && !c.is_ascii_control(),
         "[:punct:]" => c.is_ascii_punctuation(),
         "[:space:]" => c.is_ascii_whitespace(),
         "[:upper:]" => c.is_ascii_uppercase(),
         "[:word:]" => c.is_ascii_alphanumeric() || c == '_',
-        "[:xdigit:]" => c.is_digit(16),
+        "[:xdigit:]" => c.is_ascii_hexdigit(),
         _ => false,
     }
 }

--- a/src/utils/glob/extglob.rs
+++ b/src/utils/glob/extglob.rs
@@ -1,10 +1,10 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use crate::exit;
-use super::GlobElem;
 use super::comparator;
 use super::parser;
+use super::GlobElem;
+use crate::exit;
 
 pub fn shave(cands: &mut Vec<String>, prefix: char, patterns: &Vec<String>) {
     match prefix {
@@ -13,7 +13,7 @@ pub fn shave(cands: &mut Vec<String>, prefix: char, patterns: &Vec<String>) {
         '+' => more_than_zero(cands, patterns),
         '@' => once(cands, patterns),
         '!' => not(cands, patterns),
-        _   => exit::internal("unknown extglob prefix"),
+        _ => exit::internal("unknown extglob prefix"),
     }
 }
 
@@ -21,7 +21,9 @@ fn question(cands: &mut Vec<String>, patterns: &Vec<String>) {
     let mut ans = cands.clone();
     for p in patterns {
         let mut tmp = cands.clone();
-        parser::parse(p, true).iter().for_each(|w| comparator::shave(&mut tmp, &w));
+        parser::parse(p, true)
+            .iter()
+            .for_each(|w| comparator::shave(&mut tmp, w));
         ans.append(&mut tmp);
     }
     *cands = ans;
@@ -44,12 +46,13 @@ fn zero_or_more(cands: &mut Vec<String>, patterns: &Vec<String>) {
     *cands = ans;
 }
 
-fn more_than_zero(cands: &mut Vec<String>, patterns: &Vec<String>) {//TODO: buggy
+fn more_than_zero(cands: &mut Vec<String>, patterns: &Vec<String>) {
+    //TODO: buggy
     let mut ans: Vec<String> = vec![];
     let mut tmp: Vec<String> = cands.clone();
     let mut len = tmp.len();
 
-    while len > 0  {
+    while len > 0 {
         once(&mut tmp, patterns);
 
         for a in &ans {
@@ -65,7 +68,9 @@ fn once(cands: &mut Vec<String>, patterns: &Vec<String>) {
     let mut ans = vec![];
     for p in patterns {
         let mut tmp = cands.clone();
-        parser::parse(p, true).iter().for_each(|w| comparator::shave(&mut tmp, &w));
+        parser::parse(p, true)
+            .iter()
+            .for_each(|w| comparator::shave(&mut tmp, w));
         ans.append(&mut tmp);
     }
     *cands = ans;
@@ -74,8 +79,8 @@ fn once(cands: &mut Vec<String>, patterns: &Vec<String>) {
 fn not(cands: &mut Vec<String>, patterns: &Vec<String>) {
     let mut ans = vec![];
     for cand in cands.iter_mut() {
-        for prefix in make_prefix_strings(cand)  {
-            if ! once_exact_match(&prefix, patterns) {
+        for prefix in make_prefix_strings(cand) {
+            if !once_exact_match(&prefix, patterns) {
                 ans.push(cand[prefix.len()..].to_string());
             }
         }
@@ -83,20 +88,19 @@ fn not(cands: &mut Vec<String>, patterns: &Vec<String>) {
     *cands = ans;
 }
 
-fn once_exact_match(cand: &String, patterns: &Vec<String>) -> bool {
-    let mut tmp = vec![cand.clone()];
+fn once_exact_match(cand: &str, patterns: &Vec<String>) -> bool {
+    let mut tmp = vec![cand.to_string()];
     once(&mut tmp, patterns);
-    tmp.iter().any(|t| t == "")
+    tmp.iter().any(|t| t.is_empty())
 }
 
-pub fn scan(remaining: &mut String) -> (usize, Option<GlobElem>) {
-    let prefix = match remaining.chars().nth(0) {
-        Some(c) => c, 
+pub fn scan(remaining: &str) -> (usize, Option<GlobElem>) {
+    let prefix = match remaining.chars().next() {
+        Some(c) => c,
         None => return (0, None),
     };
 
-    if "?*+@!".find(prefix) == None 
-    || remaining.chars().nth(1) != Some('(') {
+    if "?*+@!".find(prefix).is_none() || remaining.chars().nth(1) != Some('(') {
         return (0, None);
     }
 
@@ -111,7 +115,7 @@ pub fn scan(remaining: &mut String) -> (usize, Option<GlobElem>) {
         len += c.len_utf8();
 
         if escaped {
-            chars.push(c); 
+            chars.push(c);
             escaped = false;
             continue;
         }
@@ -130,14 +134,16 @@ pub fn scan(remaining: &mut String) -> (usize, Option<GlobElem>) {
             nest += 1;
         }
 
-        next_nest = "?*+@!".find(c) != None;
+        next_nest = "?*+@!".find(c).is_some();
 
         if c == ')' {
             match nest {
-                0 => return {
-                    patterns.push(chars.iter().collect());
-                    (len, Some(GlobElem::ExtGlob(prefix, patterns)) )
-                },
+                0 => {
+                    return {
+                        patterns.push(chars.iter().collect());
+                        (len, Some(GlobElem::ExtGlob(prefix, patterns)))
+                    }
+                }
                 _ => nest -= 1,
             }
         }
@@ -148,12 +154,12 @@ pub fn scan(remaining: &mut String) -> (usize, Option<GlobElem>) {
     (0, None)
 }
 
-fn make_prefix_strings(s: &String) -> Vec<String> {
+fn make_prefix_strings(s: &str) -> Vec<String> {
     let mut ans = vec![];
-    let mut prefix = s.clone();
+    let mut prefix = s.to_string();
 
     ans.push(prefix.clone());
-    while prefix.len() > 0 {
+    while !prefix.is_empty() {
         prefix.pop();
         ans.push(prefix.clone());
     }

--- a/src/utils/glob/parser.rs
+++ b/src/utils/glob/parser.rs
@@ -1,37 +1,38 @@
 //SPDX-FileCopyrightText: 2024 Ryuichi Ueda <ryuichiueda@gmail.com>
 //SPDX-License-Identifier: BSD-3-Clause
 
-use super::{MetaChar, GlobElem, extglob};
+use super::{extglob, GlobElem, MetaChar};
 
 fn eat_one_char(pattern: &mut String, ans: &mut Vec<GlobElem>) -> bool {
     if pattern.starts_with("*") || pattern.starts_with("?") {
-        ans.push( GlobElem::Symbol(pattern.remove(0))  );
+        ans.push(GlobElem::Symbol(pattern.remove(0)));
         return true;
     }
     false
 }
 
 fn eat_escaped_char(pattern: &mut String, ans: &mut Vec<GlobElem>) -> bool {
-    if ! pattern.starts_with("\\") {
+    if !pattern.starts_with("\\") {
         return false;
     }
 
     if pattern.len() == 1 {
-        ans.push( GlobElem::Normal(pattern.remove(0).to_string()) );
+        ans.push(GlobElem::Normal(pattern.remove(0).to_string()));
         return true;
     }
     //ans.push( GlobElem::Normal(pattern.remove(0).to_string()) );
     pattern.remove(0);
 
-    let len = pattern.chars().nth(0).unwrap().len_utf8();
-    ans.push( GlobElem::Normal( consume(pattern, len) ) );
+    let len = pattern.chars().next().unwrap().len_utf8();
+    ans.push(GlobElem::Normal(consume(pattern, len)));
     true
 }
 
 fn cut_charclass(pattern: &mut String) -> Option<MetaChar> {
-    for c in vec!["alnum", "alpha", "ascii", "blank", "cntrl",
-                  "digit", "graph", "lower", "print", "punct",
-                  "space", "upper", "word", "xdigit"] {
+    for c in vec![
+        "alnum", "alpha", "ascii", "blank", "cntrl", "digit", "graph", "lower", "print", "punct",
+        "space", "upper", "word", "xdigit",
+    ] {
         if pattern.starts_with(&("[:".to_owned() + c + ":]")) {
             return Some(MetaChar::CharClass(consume(pattern, c.len() + 4)));
         }
@@ -56,23 +57,24 @@ fn cut_metachar(pattern: &mut String) -> Option<MetaChar> {
             let ch = pattern.chars().nth(1).unwrap();
             *pattern = pattern.split_off(ch.len_utf8() + 1);
             return Some(MetaChar::Normal(ch));
-        }else{
+        } else {
             *pattern = pattern.split_off(1);
             return None;
         }
     }
 
     if pattern.len() > 2
-    && pattern.chars().nth(1) == Some('-')
-    && pattern.chars().nth(2) != Some(']') {
-        let f = pattern.chars().nth(0).unwrap();
+        && pattern.chars().nth(1) == Some('-')
+        && pattern.chars().nth(2) != Some(']')
+    {
+        let f = pattern.chars().next().unwrap();
         let t = pattern.chars().nth(2).unwrap();
         *pattern = pattern.split_off(f.len_utf8() + 1 + t.len_utf8());
         return Some(MetaChar::Range(f, t));
     }
 
-    if pattern.len() > 0 {
-        let ch = pattern.chars().nth(0).unwrap();
+    if !pattern.is_empty() {
+        let ch = pattern.chars().next().unwrap();
         *pattern = pattern.split_off(ch.len_utf8());
         return Some(MetaChar::Normal(ch));
     }
@@ -81,20 +83,20 @@ fn cut_metachar(pattern: &mut String) -> Option<MetaChar> {
 }
 
 fn eat_bracket(pattern: &mut String, ans: &mut Vec<GlobElem>) -> bool {
-    if ! pattern.starts_with("[") {
+    if !pattern.starts_with("[") {
         return false;
     }
-    
+
     let bkup = pattern.clone();
     let not = pattern.starts_with("[^") || pattern.starts_with("[!");
-    let len = if not {2} else {1};
+    let len = if not { 2 } else { 1 };
     let mut inner = vec![];
 
     *pattern = pattern.split_off(len);
-    while pattern.len() > 0 {
+    while !pattern.is_empty() {
         if pattern.starts_with("]") {
             *pattern = pattern.split_off(1);
-            ans.push( GlobElem::OneOf(!not, inner) );
+            ans.push(GlobElem::OneOf(!not, inner));
             return true;
         }
 
@@ -120,7 +122,7 @@ fn eat_extglob(pattern: &mut String, ans: &mut Vec<GlobElem>) -> bool {
 fn eat_chars(pattern: &mut String, ans: &mut Vec<GlobElem>) -> bool {
     let mut len = 0;
     for c in pattern.chars() {
-        if "@!+*?[\\".find(c) != None {
+        if "@!+*?[\\".find(c).is_some() {
             break;
         }
         len += c.len_utf8();
@@ -131,7 +133,7 @@ fn eat_chars(pattern: &mut String, ans: &mut Vec<GlobElem>) -> bool {
     }
 
     let s = consume(pattern, len);
-    ans.push( GlobElem::Normal(s) );
+    ans.push(GlobElem::Normal(s));
     true
 }
 
@@ -140,17 +142,18 @@ pub fn parse(pattern: &str, extglob: bool) -> Vec<GlobElem> {
     let mut remaining = pattern.to_string();
     let mut ans = vec![];
 
-    while remaining.len() > 0 {
-        if (extglob && eat_extglob(&mut remaining, &mut ans) )
-        || eat_bracket(&mut remaining, &mut ans) 
-        || eat_one_char(&mut remaining, &mut ans) 
-        || eat_escaped_char(&mut remaining, &mut ans) 
-        || eat_chars(&mut remaining, &mut ans) {
+    while !remaining.is_empty() {
+        if (extglob && eat_extglob(&mut remaining, &mut ans))
+            || eat_bracket(&mut remaining, &mut ans)
+            || eat_one_char(&mut remaining, &mut ans)
+            || eat_escaped_char(&mut remaining, &mut ans)
+            || eat_chars(&mut remaining, &mut ans)
+        {
             continue;
         }
 
         let s = consume(&mut remaining, 1);
-        ans.push( GlobElem::Normal(s) );
+        ans.push(GlobElem::Normal(s));
     }
 
     ans

--- a/src/utils/splitter.rs
+++ b/src/utils/splitter.rs
@@ -1,32 +1,33 @@
 //SPDX-FileCopyrightText: 2025 @caro@mi.shellgei.org
 //SPDX-License-Identifier: BSD-3-Clause
 
-pub fn split(sw: &str, ifs: &str, prev_char: Option<char>) -> Vec<(String, bool)>{ //bool: true if it should remain
-    if ifs == "" {
+pub fn split(sw: &str, ifs: &str, prev_char: Option<char>) -> Vec<(String, bool)> {
+    //bool: true if it should remain
+    if ifs.is_empty() {
         return vec![(sw.to_string(), false)];
     }
 
-    if ifs.chars().all(|c| " \t\n".contains(c) ) {
+    if ifs.chars().all(|c| " \t\n".contains(c)) {
         split_str_normal(sw, ifs)
-    }else {
+    } else {
         split_str_special(sw, ifs, prev_char)
     }
 }
 
-fn scanner_blank(s: &str, blank: &Vec<char>) -> usize {
+fn scanner_blank(s: &str, blank: &[char]) -> usize {
     let mut ans = 0;
     let mut esc = false;
 
     for ch in s.chars() {
         if esc || ch == '\\' {
-            esc = ! esc;
+            esc = !esc;
             ans += ch.len_utf8();
             continue;
         }
 
         if blank.contains(&ch) {
             ans += ch.len_utf8();
-        }else {
+        } else {
             break;
         }
     }
@@ -34,13 +35,13 @@ fn scanner_blank(s: &str, blank: &Vec<char>) -> usize {
     ans
 }
 
-fn scanner_ifs_blank(s: &str, blank: &Vec<char>, delim: &Vec<char>) -> usize {
+fn scanner_ifs_blank(s: &str, blank: &[char], delim: &[char]) -> usize {
     let mut ans = 0;
     let mut esc = false;
 
     for ch in s.chars() {
         if esc || ch == '\\' {
-            esc = ! esc;
+            esc = !esc;
             ans += ch.len_utf8();
             continue;
         }
@@ -49,9 +50,9 @@ fn scanner_ifs_blank(s: &str, blank: &Vec<char>, delim: &Vec<char>) -> usize {
             ans += ch.len_utf8();
             ans += scanner_blank(&s[ans..], blank);
             return ans;
-        }else if blank.contains(&ch) {
+        } else if blank.contains(&ch) {
             ans += ch.len_utf8();
-        }else {
+        } else {
             break;
         }
     }
@@ -64,12 +65,12 @@ fn split_str_special(s: &str, ifs: &str, prev_char: Option<char>) -> Vec<(String
     let mut remaining = s.to_string();
 
     let shave_prev = match prev_char {
-        None    => true,
+        None => true,
         Some(c) => " \t\n".contains(c),
     };
 
-    let blank: Vec<char> = ifs.chars().filter(|s| " \t\n".contains(*s)).collect(); 
-    let delim: Vec<char> = ifs.chars().filter(|s| ! " \t\n".contains(*s)).collect(); 
+    let blank: Vec<char> = ifs.chars().filter(|s| " \t\n".contains(*s)).collect();
+    let delim: Vec<char> = ifs.chars().filter(|s| !" \t\n".contains(*s)).collect();
 
     if shave_prev {
         let len = scanner_blank(&remaining, &blank);
@@ -77,7 +78,7 @@ fn split_str_special(s: &str, ifs: &str, prev_char: Option<char>) -> Vec<(String
         remaining = tail;
     }
 
-    while ! remaining.is_empty() {
+    while !remaining.is_empty() {
         let len = scanner_word(&remaining, ifs);
         let tail = remaining.split_off(len);
 
@@ -110,12 +111,12 @@ fn split_str_normal(s: &str, ifs: &str) -> Vec<(String, bool)> {
     for c in s.chars() {
         pos += c.len_utf8();
         if esc || c == '\\' {
-            esc = ! esc;
+            esc = !esc;
             continue;
         }
 
         if ifs.contains(c) {
-            let sw = s[from..pos-c.len_utf8()].to_string();
+            let sw = s[from..pos - c.len_utf8()].to_string();
             ans.push((sw, false));
             from = pos;
         }
@@ -132,7 +133,7 @@ fn scanner_word(s: &str, ifs: &str) -> usize {
 
     for ch in s.chars() {
         if esc || ch == '\\' {
-            esc = ! esc;
+            esc = !esc;
             ans += ch.len_utf8();
             continue;
         }
@@ -146,4 +147,3 @@ fn scanner_word(s: &str, ifs: &str) -> usize {
 
     ans
 }
-


### PR DESCRIPTION
Corrected 705 warnings to 2.
The remaining warnings are related to too many function arguments, which seems to require data structure modifications.